### PR TITLE
Remove Private Set From ATProtocolConfiguration

### DIFF
--- a/Sources/ATProtoKit/Networking/SessionManager/ATProtocolConfiguration.swift
+++ b/Sources/ATProtoKit/Networking/SessionManager/ATProtocolConfiguration.swift
@@ -18,7 +18,7 @@ public class ATProtocolConfiguration: ProtocolConfiguration {
     public var appPassword: String
 
     /// The URL of the Personal Data Server (PDS).
-public var pdsURL: String
+    public var pdsURL: String
 
     /// Specifies the logger that will be used for emitting log messages.
     public private(set) var logger: Logger?

--- a/Sources/ATProtoKit/Networking/SessionManager/ATProtocolConfiguration.swift
+++ b/Sources/ATProtoKit/Networking/SessionManager/ATProtocolConfiguration.swift
@@ -18,7 +18,7 @@ public class ATProtocolConfiguration: ProtocolConfiguration {
     public var appPassword: String
 
     /// The URL of the Personal Data Server (PDS).
-    public private(set) var pdsURL: String
+public var pdsURL: String
 
     /// Specifies the logger that will be used for emitting log messages.
     public private(set) var logger: Logger?

--- a/Sources/ATProtoKit/Networking/SessionManager/ATProtocolConfiguration.swift
+++ b/Sources/ATProtoKit/Networking/SessionManager/ATProtocolConfiguration.swift
@@ -12,10 +12,10 @@ import Logging
 public class ATProtocolConfiguration: ProtocolConfiguration {
 
     /// The user's handle identifier in their account.
-    public private(set) var handle: String
+    public var handle: String
 
     /// The app password of the user's account.
-    public private(set) var appPassword: String
+    public var appPassword: String
 
     /// The URL of the Personal Data Server (PDS).
     public private(set) var pdsURL: String


### PR DESCRIPTION
## Description
Describe in detail what this Pull Request does and why it’s needed. Include anything the reviewers need to be aware of.

This PR changes the handle and app password to have public setters. This is needed to be able to try to sign in again in the event of an unsuccessful login, and pass in a corrected set of handle and app password.

## Linked Issues
N/A

## Type of Change
- [X] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [X] My code follows the ATProtoKit API Design Guidelines as well as the Swift API Design Guidelines.
- [X] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings or errors in the compiler or runtime.
- [X] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
N/A

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Joshua Holme]
- GitHub: [JoshuaHolme]
- Bluesky: [josh.holme.social]
