### PR TITLE
[Bug Fix] Fix Threading Errors By Passing Session to URI Resolution

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
@@ -59,7 +59,7 @@ extension ATProtoBluesky {
         var resolvedReplyTo: AppBskyLexicon.Feed.PostRecord.ReplyReference? = nil
         if let replyURI = replyTo {
             do {
-                resolvedReplyTo = try await ATProtoTools().resolveReplyReferences(parentURI: replyURI)
+                resolvedReplyTo = try await ATProtoTools().resolveReplyReferences(parentURI: replyURI, session: session)
             } catch {
                 throw error
             }

--- a/Sources/ATProtoKit/Utilities/ATProtoTools.swift
+++ b/Sources/ATProtoKit/Utilities/ATProtoTools.swift
@@ -29,8 +29,8 @@ public class ATProtoTools {
     ///
     /// - Parameter parentURI: The URI of the post record the current one is directly replying to.
     /// - Returns: A ``AppBskyLexicon/Feed/PostRecord/ReplyReference``.
-    public func resolveReplyReferences(parentURI: String) async throws -> AppBskyLexicon.Feed.PostRecord.ReplyReference {
-        let threadRecords = try await fetchRecordForURI(parentURI)
+    public func resolveReplyReferences(parentURI: String, session: UserSession? = nil) async throws -> AppBskyLexicon.Feed.PostRecord.ReplyReference {
+        let threadRecords = try await fetchRecordForURI(parentURI, session: session)
 
         guard let parentRecord = threadRecords.value else {
             return createReplyReference(from: threadRecords)
@@ -80,11 +80,11 @@ public class ATProtoTools {
     ///
     /// - Parameter uri: The URI of the record.
     /// - Returns: A ``ComAtprotoLexicon/Repository/GetRecordOutput``
-    public func fetchRecordForURI(_ uri: String) async throws -> ComAtprotoLexicon.Repository.GetRecordOutput {
+    public func fetchRecordForURI(_ uri: String, session: UserSession? = nil) async throws -> ComAtprotoLexicon.Repository.GetRecordOutput {
         let query = try parseURI(uri)
 
         do {
-            let record = try await ATProtoKit().getRepositoryRecord(from: query.repository, collection: query.collection, recordKey: query.recordKey, pdsURL: nil)
+            let record = try await ATProtoKit().getRepositoryRecord(from: query.repository, collection: query.collection, recordKey: query.recordKey, pdsURL: session?.pdsURL)
 
             return record
         } catch {


### PR DESCRIPTION
## Description
My spelunking of the code revealed that the `fetchRecordForURI()` method expects to have a working `UserSession` instance in order to get a `pdsURL` value. But because the method belongs to a bare utility class, it has no such association. Therefore, all attempts to resolve URIs used to resolve posts for threading will always fail. My solution is pretty naive, and I'm 95% sure y'all will shoot it down. I'm happy to play ball to help you get all the right parts talking to each other.

## Linked Issues
#32 

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [ ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [ ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [ ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Aaron Vegh]
- GitHub: [aaronvegh]
- Bluesky: [aaronvegh.bsky.social]
