### PR TITLE
Handle unicode strings when parsing hashtags, links, mentions

### DIFF
--- a/Sources/ATProtoKit/Utilities/ATFacetParser.swift
+++ b/Sources/ATProtoKit/Utilities/ATFacetParser.swift
@@ -42,16 +42,20 @@ public class ATFacetParser {
 
                 let nsRange = match.range(at: 1)
                 if let range = Range(nsRange, in: text) {
-                    let utf8Start = text.utf8.distance(from: text.utf8.startIndex, to: range.lowerBound.samePosition(in: text.utf8)!)
-                    let utf8End = text.utf8.distance(from: text.utf8.startIndex, to: range.upperBound.samePosition(in: text.utf8)!)
+                    if let lowerBound = range.lowerBound.samePosition(in: text.utf8),
+                       let upperBound = range.upperBound.samePosition(in: text.utf8) {
 
-                    let mentionText = String(text[range])
+                        let utf8Start = text.utf8.distance(from: text.utf8.startIndex, to: lowerBound)
+                        let utf8End = text.utf8.distance(from: text.utf8.startIndex, to: upperBound)
 
-                    spans.append([
-                        "start": utf8Start,
-                        "end": utf8End,
-                        "mention": mentionText
-                    ])
+                        let mentionText = String(text[range])
+
+                        spans.append([
+                            "start": utf8Start,
+                            "end": utf8End,
+                            "mention": mentionText
+                        ])
+                    }
                 }
             }
         } catch {
@@ -80,16 +84,20 @@ public class ATFacetParser {
 
                 let nsRange = match.range(at: 1)
                 if let range = Range(nsRange, in: text) {
-                    let utf8Start = text.utf8.distance(from: text.utf8.startIndex, to: range.lowerBound.samePosition(in: text.utf8)!)
-                    let utf8End = text.utf8.distance(from: text.utf8.startIndex, to: range.upperBound.samePosition(in: text.utf8)!)
+                    if let lowerBound = range.lowerBound.samePosition(in: text.utf8),
+                       let upperBound = range.upperBound.samePosition(in: text.utf8) {
 
-                    let linkText = String(text[range])
+                        let utf8Start = text.utf8.distance(from: text.utf8.startIndex, to: lowerBound)
+                        let utf8End = text.utf8.distance(from: text.utf8.startIndex, to: upperBound)
 
-                    spans.append([
-                        "start": utf8Start,
-                        "end": utf8End,
-                        "link": linkText
-                    ])
+                        let linkText = String(text[range])
+
+                        spans.append([
+                            "start": utf8Start,
+                            "end": utf8End,
+                            "link": linkText
+                        ])
+                    }
                 }
             }
         } catch {
@@ -118,16 +126,20 @@ public class ATFacetParser {
 
                 let nsRange = match.range(at: 1)
                 if let range = Range(nsRange, in: text) {
-                    let utf8Start = text.utf8.distance(from: text.utf8.startIndex, to: range.lowerBound.samePosition(in: text.utf8)!)
-                    let utf8End = text.utf8.distance(from: text.utf8.startIndex, to: range.upperBound.samePosition(in: text.utf8)!)
-
-                    let hashtagText = String(text[range])
-
-                    spans.append([
-                        "start": utf8Start,
-                        "end": utf8End,
-                        "tag": hashtagText
-                    ])
+                    if let lowerBound = range.lowerBound.samePosition(in: text.utf8),
+                       let upperBound = range.upperBound.samePosition(in: text.utf8) {
+                        
+                        let utf8Start = text.utf8.distance(from: text.utf8.startIndex, to: lowerBound)
+                        let utf8End = text.utf8.distance(from: text.utf8.startIndex, to: upperBound)
+                        
+                        let hashtagText = String(text[range])
+                        
+                        spans.append([
+                            "start": utf8Start,
+                            "end": utf8End,
+                            "tag": hashtagText
+                        ])
+                    }
                 }
             }
         } catch {

--- a/Sources/ATProtoKit/Utilities/ATFacetParser.swift
+++ b/Sources/ATProtoKit/Utilities/ATFacetParser.swift
@@ -30,32 +30,29 @@ public class ATFacetParser {
     public static func parseMentions(from text: String) -> [[String: Any]] {
         var spans = [[String: Any]]()
 
-        // Regex for grabbing @mentions.
-        // Based on Bluesky's regex.
+        // Regex for grabbing @mentions based on Bluesky's regex.
         let mentionRegex = "[\\s|^](@([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)"
 
         do {
             let regex = try NSRegularExpression(pattern: mentionRegex)
             let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
 
-            // Get the start and end positions of each match.
-            regex.enumerateMatches(in: text, options: [], range: nsRange) { match, _, _ in
-                guard let match = match,
-                      let range = Range(match.range(at: 1), in: text) else { return }
+            regex.enumerateMatches(in: text, range: nsRange) { match, _, _ in
+                guard let match = match else { return }
 
-                // Text must be in a UTF-8 encoded bytestring offset.
-                let utf8Text = text.utf8
-                let byteStart = utf8Text.distance(from: utf8Text.startIndex,
-                                                  to: utf8Text.index(utf8Text.startIndex, offsetBy: text.distance(from: text.startIndex, to: range.lowerBound)))
-                let byteEnd = utf8Text.distance(from: utf8Text.startIndex,
-                                                to: utf8Text.index(utf8Text.startIndex, offsetBy: text.distance(from: text.startIndex, to: range.upperBound)))
-                let mentionText = String(text[range])
+                let nsRange = match.range(at: 1)
+                if let range = Range(nsRange, in: text) {
+                    let utf8Start = text.utf8.distance(from: text.utf8.startIndex, to: range.lowerBound.samePosition(in: text.utf8)!)
+                    let utf8End = text.utf8.distance(from: text.utf8.startIndex, to: range.upperBound.samePosition(in: text.utf8)!)
 
-                spans.append([
-                    "start": byteStart,
-                    "end": byteEnd,
-                    "mention": mentionText
-                ])
+                    let mentionText = String(text[range])
+
+                    spans.append([
+                        "start": utf8Start,
+                        "end": utf8End,
+                        "mention": mentionText
+                    ])
+                }
             }
         } catch {
             print("Invalid regex: \(error.localizedDescription)")
@@ -71,28 +68,29 @@ public class ATFacetParser {
     public static func parseURLs(from text: String) -> [[String: Any]] {
         var spans = [[String: Any]]()
 
-        // Regex for grabbing links.
-        // Don't know if it can get every possible link.
-        // Based on the regex Bluesky grabbed.
+        // Regular expression pattern for identifying URLs.
         let linkRegex = "[\\s|^](https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*[-a-zA-Z0-9@%_\\+~#//=])?)"
 
         do {
             let regex = try NSRegularExpression(pattern: linkRegex)
             let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
 
-            // Get the start and end positions of each match.
             regex.enumerateMatches(in: text, range: nsRange) { match, _, _ in
-                guard let match = match,
-                      let range = Range(match.range(at: 1), in: text) else { return }
-                let byteStart = text.distance(from: text.startIndex, to: range.lowerBound)
-                let byteEnd = text.distance(from: text.startIndex, to: range.upperBound)
-                let linkText = String(text[range])
+                guard let match = match else { return }
 
-                spans.append([
-                    "start": byteStart,
-                    "end": byteEnd,
-                    "link": linkText
-                ])
+                let nsRange = match.range(at: 1)
+                if let range = Range(nsRange, in: text) {
+                    let utf8Start = text.utf8.distance(from: text.utf8.startIndex, to: range.lowerBound.samePosition(in: text.utf8)!)
+                    let utf8End = text.utf8.distance(from: text.utf8.startIndex, to: range.upperBound.samePosition(in: text.utf8)!)
+
+                    let linkText = String(text[range])
+
+                    spans.append([
+                        "start": utf8Start,
+                        "end": utf8End,
+                        "link": linkText
+                    ])
+                }
             }
         } catch {
             print("Invalid regex: \(error.localizedDescription)")
@@ -108,26 +106,29 @@ public class ATFacetParser {
     public static func parseHashtags(from text: String) -> [[String: Any]] {
         var spans = [[String: Any]]()
 
-        // Regex for grabbing #hashtags.
-        let hashtagRegex = "(?<!\\w)(#[a-zA-Z0-9_]+)"
+        // Regex pattern for identifying hashtags.
+        let hashtagRegex = "(?<!\\w)(#[\\p{L}\\p{M}\\p{N}_]+)"
 
         do {
             let regex = try NSRegularExpression(pattern: hashtagRegex)
             let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
 
-            // Get the start and end positions of each match.
             regex.enumerateMatches(in: text, range: nsRange) { match, _, _ in
-                guard let match = match,
-                      let range = Range(match.range(at: 1), in: text) else { return }
-                let byteStart = text.distance(from: text.startIndex, to: range.lowerBound)
-                let byteEnd = text.distance(from: text.startIndex, to: range.upperBound)
-                let hashtagText = String(text[range])
+                guard let match = match else { return }
 
-                spans.append([
-                    "start": byteStart,
-                    "end": byteEnd,
-                    "tag": hashtagText
-                ])
+                let nsRange = match.range(at: 1)
+                if let range = Range(nsRange, in: text) {
+                    let utf8Start = text.utf8.distance(from: text.utf8.startIndex, to: range.lowerBound.samePosition(in: text.utf8)!)
+                    let utf8End = text.utf8.distance(from: text.utf8.startIndex, to: range.upperBound.samePosition(in: text.utf8)!)
+
+                    let hashtagText = String(text[range])
+
+                    spans.append([
+                        "start": utf8Start,
+                        "end": utf8End,
+                        "tag": hashtagText
+                    ])
+                }
             }
         } catch {
             print("Invalid regex: \(error.localizedDescription)")


### PR DESCRIPTION
## Description
When the user posts text that contains non-ascii characters (süch às 💭), the simple ASCII-based range finders flake right out. The issue I created provides examples of what happened when a German did a post with my app. 😬 

My update updates the hashtag regex to include more-inclusive matchers for unicode letters, and uses String.Index values, which are sensitive to multi-byte strings.

## Linked Issues
#35 

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [ ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [ ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [ ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: Aaron Vegh
- GitHub: aaronvegh
