### PR TITLE
Remove literal # from hashtags during posting

### DIFF
--- a/Sources/ATProtoKit/Utilities/ATFacetParser.swift
+++ b/Sources/ATProtoKit/Utilities/ATFacetParser.swift
@@ -220,13 +220,15 @@ public class ATFacetParser {
                 group.addTask {
                     // Unless something is wrong with `parseHashtags()`, this is unlikely to fail.
                     guard let tag = hashtag["tag"] as? String else { return }
-                    print("Hashtag: \(tag)")
+                    // rid us of this meddlesome "#" character
+                    let unhashedTag = String(tag.dropFirst())
+                    print("Hashtag: \(unhashedTag)")
 
                     if let start = hashtag["start"] as? Int,
                        let end = hashtag["end"] as? Int {
                         let hashTagFacet = AppBskyLexicon.RichText.Facet(
                             index: AppBskyLexicon.RichText.Facet.ByteSlice(byteStart: start, byteEnd: end),
-                            features: [.tag(AppBskyLexicon.RichText.Facet.Tag(tag: tag))]
+                            features: [.tag(AppBskyLexicon.RichText.Facet.Tag(tag: unhashedTag))]
                         )
 
                         await facets.append(hashTagFacet)


### PR DESCRIPTION
## Description
When users post with a hashtag, ATProtoKit kindly parses the text and creates a facet. The text of the facet includes the "#" character. On Bluesky, the resulting post appears with a single hashtag, but tapping on it reveals a double-hash — in other words, the hashtag includes the "#" character, so it becomes "##hashtag". 

Here's an example with a post done with the current version of ATProtoKit: 

https://bsky.app/profile/croissantageddon.bsky.social/post/3l7gi2g2env2u

This change simply snips off that opening # character during facet parsing, so the tag content doesn't have one. Here's an example post using this PR:

https://bsky.app/profile/croissantageddon.bsky.social/post/3l7jbwgvprt2u

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [ ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [ ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [ ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
