### PR TITLE
Ensure mention lookups work

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
@@ -96,7 +96,7 @@ extension ATProtoBluesky {
         // Compiling all parts of the post into one.
         let postRecord = AppBskyLexicon.Feed.PostRecord(
             text: postText,
-            facets: await ATFacetParser.parseFacets(from: postText, pdsURL: session.accessToken),
+            facets: await ATFacetParser.parseFacets(from: postText, pdsURL: session.pdsURL ?? "https://bsky.social"),
             reply: resolvedReplyTo,
             embed: resolvedEmbed,
             languages: localeIdentifiers,

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Identity/ComAtprotoIdentityResolveHandle.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Identity/ComAtprotoIdentityResolveHandle.swift
@@ -17,6 +17,6 @@ extension ComAtprotoLexicon.Identity {
     public struct ResolveHandleOutput: Sendable, Decodable {
 
         /// The resolved handle's decentralized identifier (DID).
-        public let handleDID: String
+        public let did: String
     }
 }

--- a/Sources/ATProtoKit/Utilities/ATFacetParser.swift
+++ b/Sources/ATProtoKit/Utilities/ATFacetParser.swift
@@ -187,7 +187,7 @@ public class ATFacetParser {
 
                         let mentionFacet = AppBskyLexicon.RichText.Facet(
                             index: AppBskyLexicon.RichText.Facet.ByteSlice(byteStart: start, byteEnd: end),
-                            features: [.mention(AppBskyLexicon.RichText.Facet.Mention(did: mentionResult.handleDID))])
+                            features: [.mention(AppBskyLexicon.RichText.Facet.Mention(did: mentionResult.did))])
 
                         await facets.append(mentionFacet)
                     } catch {


### PR DESCRIPTION
## Description
I noticed that calls to `resolveHandle` were failing: it appears the pdsURL was being replaced with an access token JWT. This was preventing my Bsky client from being able to post @-mentions.

In providing this fix, I made two changes:

1. I set the pdsURL to the session's `pdsURL` rather than the access token. This must've been an error made earlier.
2. I also noted that the response JSON from the AT protocol endpoint returns a `did` property, not a `handleDID`. Changing that got it all flowing right again.

## Linked Issues
#45 

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [ ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [ ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [ ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
