### PR TITLE
Widens the Swift Syntax version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-docc-plugin.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/MasterJ93/SwiftCBOR.git", from: "0.4.0"),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "509.0.0")
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0" ..< "601.0.0-prerelease")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
## Description
This widens the version of Swift Syntax that ATProtoKit can point to.
This is important as if someone using ATProtoKit depends on a library that uses a later version of Swift Syntax, e.g. 510.0.0, 600.0.0, etc. then the dependencies cannot resolve. Even though the code uses the `from` version of the `package` static method, Apple have used major version semantic versioning bumps for new minor versions of Swift (and for major versions).
Pointing to a wider range of Swift Syntax versions resolves this problem, and allows for wider Swift Syntax version resolution.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Additional Notes
Following guidance from Point-Free: https://www.pointfree.co/blog/posts/116-being-a-good-citizen-in-the-land-of-swiftsyntax

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Rhys Morgan]
- GitHub: [rhysm94]
- Bluesky: [rhysm.wales]
