### PR TITLE
Forward the session authorization for getPopularFeedGenerators

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetPopularFeedGenerators.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetPopularFeedGenerators.swift
@@ -35,6 +35,11 @@ extension ATProtoKit {
         limit: Int? = 50,
         cursor: String? = nil
     ) async throws -> AppBskyLexicon.Unspecced.GetPopularFeedGeneratorsOutput {
+        guard session != nil,
+              let accessToken = session?.accessToken else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
         guard let sessionURL = session?.pdsURL,
               let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.unspecced.getPopularFeedGenerators") else {
             throw ATRequestPrepareError.invalidRequestURL
@@ -68,7 +73,7 @@ extension ATProtoKit {
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
-                authorizationValue: nil
+                authorizationValue: "Bearer \(accessToken)"
             )
             let response = try await APIClientService.shared.sendRequest(
                 request,


### PR DESCRIPTION
## Description
Forward the session authorization for `getPopularFeedGenerators`

## Linked Issues
Link any related issues here. Format: `#[issue number]`

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.


## Additional Notes
Forward the session authorization for `getPopularFeedGenerators` as it's required, for now we get the error 
`unauthorized(error: ATProtoKit.ATHTTPResponseError(error: "AuthMissing", message: "Authentication Required"), wwwAuthenticate: nil)`

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: Thomas Ricouard
- GitHub: https://github.com/Dimillian
- Bluesky: https://bsky.app/profile/dimillian.app
