### PR TITLE
Fix GetPreferences

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorGetPreferences.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorGetPreferences.swift
@@ -22,5 +22,9 @@ extension AppBskyLexicon.Actor {
 
         /// The array of preferences in the user's account.
         public let preference: PreferencesDefinition
+      
+        public init(from decoder: any Decoder) throws {
+          self.preference = try .init(from: decoder)
+        }
     }
 }


### PR DESCRIPTION
## Description
Fix `GetPreferences` by forwarding the root container without trying to parse it. As there is no `preference.preferences` key but simply a root `[preferences]` array.


## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.
