### PR TITLE
Potential fix to the embed records not decoding correctly

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Graph/AppBskyGraphDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Graph/AppBskyGraphDefs.swift
@@ -101,6 +101,11 @@ extension AppBskyLexicon.Graph {
     /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/graph/defs.json
     public struct ListViewDefinition: Sendable, Codable {
 
+        /// The identifier of the lexicon.
+        ///
+        /// - Warning: The value must not change.
+        public let type: String = "app.bsky.graph.defs#listView"
+        
         /// The URI of the user list.
         public let listURI: String
 
@@ -158,7 +163,12 @@ extension AppBskyLexicon.Graph {
 
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-
+            
+            let decodedType = try container.decode(String.self, forKey: .type)
+            if decodedType != type {
+                throw DecodingError.typeMismatch(ListViewDefinition.self, .init(codingPath: [CodingKeys.type], debugDescription: "type did not match expected type \(type)"))
+            }
+                 
             self.listURI = try container.decode(String.self, forKey: .listURI)
             self.cidHash = try container.decode(String.self, forKey: .cidHash)
             self.creator = try container.decode(AppBskyLexicon.Actor.ProfileViewDefinition.self, forKey: .creator)
@@ -193,6 +203,7 @@ extension AppBskyLexicon.Graph {
         }
 
         enum CodingKeys: String, CodingKey {
+            case type = "$type"
             case listURI = "uri"
             case cidHash = "cid"
             case creator = "creator"
@@ -339,6 +350,11 @@ extension AppBskyLexicon.Graph {
     /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/graph/defs.json
     public struct StarterPackViewBasicDefinition: Sendable, Codable {
 
+        /// The identifier of the lexicon.
+        ///
+        /// - Warning: The value must not change.
+        public let type: String = "app.bsky.graph.defs#starterPackViewBasic"
+
         /// The URI of the starter pack.
         public let starterPackURI: String
 
@@ -370,7 +386,12 @@ extension AppBskyLexicon.Graph {
 
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-
+            
+            let decodedType = try container.decode(String.self, forKey: .type)
+            if decodedType != type {
+                throw DecodingError.typeMismatch(ListViewDefinition.self, .init(codingPath: [CodingKeys.type], debugDescription: "type did not match expected type \(type)"))
+            }
+                 
             self.starterPackURI = try container.decode(String.self, forKey: CodingKeys.starterPackURI)
             self.starterPackCID = try container.decode(String.self, forKey: .starterPackCID)
             self.starterPackRecord = try container.decode(UnknownType.self, forKey: .starterPackRecord)
@@ -397,6 +418,7 @@ extension AppBskyLexicon.Graph {
         }
 
         enum CodingKeys: String, CodingKey {
+            case type = "$type"
             case starterPackURI = "uri"
             case starterPackCID = "cid"
             case starterPackRecord = "record"

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Labeler/AppBskyLabelerDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Labeler/AppBskyLabelerDefs.swift
@@ -16,6 +16,11 @@ extension AppBskyLexicon.Labeler {
     /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/labeler/defs.json
     public struct LabelerViewDefinition: Sendable, Codable {
 
+        /// The identifier of the lexicon.
+        ///
+        /// - Warning: The value must not change.
+        public let type: String = "app.bsky.labeler.defs#labelerView"
+        
         /// The URI of the labeler.
         public let labelerURI: String
 
@@ -50,6 +55,11 @@ extension AppBskyLexicon.Labeler {
 
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
+            
+            let decodedType = try container.decode(String.self, forKey: .type)
+            if decodedType != type {
+                throw DecodingError.typeMismatch(LabelerViewDefinition.self, .init(codingPath: [CodingKeys.type], debugDescription: "type did not match expected type \(type)"))
+            }
 
             self.labelerURI = try container.decode(String.self, forKey: .labelerURI)
             self.labelerCIDHash = try container.decode(String.self, forKey: .labelerCIDHash)
@@ -76,6 +86,7 @@ extension AppBskyLexicon.Labeler {
         }
 
         enum CodingKeys: String, CodingKey {
+            case type = "$type"
             case labelerURI = "uri"
             case labelerCIDHash = "cid"
             case creator


### PR DESCRIPTION
## Description
This pull request attempts to fix the issues encountered in #55 by implementing a type variable and the corresponding CodingKey enum and then decoding for the type variable, and comparing the decoded variable with the correct type variable to see if we should continue decoding, or if we should throw an error that we are decoding the wrong type.

## Linked Issues
#55 

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Additional Notes
This is a pull request to attempt to fix one of the issues I've encountered in #55 after some discussions with the owner of the repo as well as digging into the codebase itself. 

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: Andy Lin
- GitHub: @andylin2004
- Bluesky: [Replace with your Bluesky handle if you have one]
