### PR TITLE
Set default user agent

### DIFF
--- a/Sources/ATProtoKit/Utilities/APIClientService.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientService.swift
@@ -68,7 +68,7 @@ public actor APIClientService {
 
         /// This needs to be updated manually or read from a central location
         ///  To get truly accurate version would need to read from Package.resolved and I haven't found a way to do so
-        let atProtoVersion = "ATProtoKit/2.0.0"
+        let atProtoVersion = "ATProtoKit/0.21.0"
 
         let userAgent = "\(executable)/\(appVersion) (\(bundle); build:\(appBuild); \(osNameVersion)) \(atProtoVersion)"
 

--- a/Sources/ATProtoKit/Utilities/APIClientService.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientService.swift
@@ -19,17 +19,74 @@ public actor APIClientService {
 
     /// The `URLSession` instance to be used for network requests.
     private(set) var urlSession: URLSession
+    
+    /// The `UserAgent` instance to identify all network requests originating from the `ATProtoKit` sdk
+    public static let userAgent: String = {
+        let info = Bundle.main.infoDictionary
+        let executable = (info?["CFBundleExecutable"] as? String) ??
+            (ProcessInfo.processInfo.arguments.first?.split(separator: "/").last.map(String.init)) ??
+            "Unknown"
+        let bundle = info?["CFBundleIdentifier"] as? String ?? "Unknown"
+        let appVersion = info?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        let appBuild = info?["CFBundleVersion"] as? String ?? "Unknown"
+
+        let osNameVersion: String = {
+            let version = ProcessInfo.processInfo.operatingSystemVersion
+            let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+            let osName: String = {
+                #if os(iOS)
+                #if targetEnvironment(macCatalyst)
+                return "macOS(Catalyst)"
+                #else
+                return "iOS"
+                #endif
+                #elseif os(watchOS)
+                return "watchOS"
+                #elseif os(tvOS)
+                return "tvOS"
+                #elseif os(macOS)
+                #if targetEnvironment(macCatalyst)
+                return "macOS(Catalyst)"
+                #else
+                return "macOS"
+                #endif
+                #elseif swift(>=5.9.2) && os(visionOS)
+                return "visionOS"
+                #elseif os(Linux)
+                return "Linux"
+                #elseif os(Windows)
+                return "Windows"
+                #elseif os(Android)
+                return "Android"
+                #else
+                return "Unknown"
+                #endif
+            }()
+
+            return "\(osName) \(versionString)"
+        }()
+
+        /// This needs to be updated manually or read from a central location
+        ///  To get truly accurate version would need to read from Package.resolved and I haven't found a way to do so
+        let atProtoVersion = "ATProtoKit/2.0.0"
+
+        let userAgent = "\(executable)/\(appVersion) (\(bundle); build:\(appBuild); \(osNameVersion)) \(atProtoVersion)"
+
+        return userAgent
+    }()
 
     /// A `URLSession` object for use in all HTTP requests.
     public static let shared = APIClientService()
 
     /// Creates an instance for use in accepting and returning API requests and
     /// responses respectively.
-    /// 
+    ///
     /// - Parameter configuration: An instance of `URLSessionConfiguration`.
     /// Defaults to `.default`.
     private init() {
-        self.urlSession = URLSession(configuration: .default)
+        let sessionConfig = URLSessionConfiguration.default
+        sessionConfig.httpAdditionalHeaders = ["User-Agent": APIClientService.userAgent]
+        self.urlSession = URLSession(configuration: sessionConfig)
     }
 
     /// Configures the singleton instance with a custom `URLSessionConfiguration`.
@@ -52,6 +109,7 @@ public actor APIClientService {
     ///   - labelersValue: The `atproto-accept-labelers` value. Optional.
     ///   - isRelatedToBskyChat: Indicates whether to use the "atproto-proxy" header for
     ///   the value specific to Bluesky DMs. Optional. Defaults to `false`.
+    ///  - userAgent: The user agent of the client. Defaults to `.default`.
     /// - Returns: A configured `URLRequest` instance.
     public static func createRequest(forRequest requestURL: URL, andMethod httpMethod: HTTPMethod, acceptValue: String? = "application/json",
                                      contentTypeValue: String? = "application/json", authorizationValue: String? = nil,
@@ -95,7 +153,6 @@ public actor APIClientService {
         }
         return httpBody
     }
-
 
     /// Sets query items for a given URL.
     ///


### PR DESCRIPTION
## Description
Sets a default user agent that identifies network requests from this SPM

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
We could add a method for users to update with their own custom user agent down the line, but they can update the ['User-Agent'] header currently if they so desire.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Adam Rowe]
- GitHub: [airowe]
- Bluesky: [airowe@bsky.social]
- Email: [adaminsley@gmail.com]
