### PR TITLE
Adds the ability to create and delete a repost record

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/RepostRecord/CreateRepostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/RepostRecord/CreateRepostRecord.swift
@@ -8,5 +8,29 @@
 import Foundation
 
 extension ATProtoBluesky {
+  public func createRepostRecord(
+    _ strongReference: ComAtprotoLexicon.Repository.StrongReference,
+    createdAt: Date = Date(),
+    shouldValidate: Bool? = true
+  ) async throws -> ComAtprotoLexicon.Repository.StrongReference {
+    guard let session else { throw ATRequestPrepareError.missingActiveSession }
 
+    let repostRecord = AppBskyLexicon.Feed.RepostRecord(
+      subject: strongReference,
+      createdAt: createdAt
+    )
+
+    return try await atProtoKitInstance.createRecord(
+      repositoryDID: session.sessionDID,
+      collection: "app.bsky.feed.repost",
+      shouldValidate: shouldValidate,
+      record: .record(repostRecord)
+    )
+  }
+
+  struct RepostRecordRequestBody: Encodable {
+    let repo: String
+    let collection: String = "app.bsky.feed.repost"
+    let record: AppBskyLexicon.Feed.RepostRecord
+  }
 }

--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/RepostRecord/DeleteRepostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/RepostRecord/DeleteRepostRecord.swift
@@ -9,4 +9,86 @@ import Foundation
 
 extension ATProtoBluesky {
 
+  /// Deletes a repost record.
+  ///
+  /// This can also be used to validate if a repost record has been deleted.
+  /// - Parameter record: The record that needs to be deleted.
+  ///
+  /// This can be either the URI of the record, or the full record object itself.
+  public func deleteRepostRecord(_ record: RecordIdentifier) async throws {
+    guard let session else {
+      throw ATRequestPrepareError.missingActiveSession
+    }
+
+    guard let sessionURL = session.pdsURL else {
+      throw ATRequestPrepareError.invalidRequestURL
+    }
+
+    var repostRecord: ATProtoTools.RecordQuery? = nil
+    try await resolveRecordIdentifierToQuery(record, sessionURL, &repostRecord)
+
+    let requestBody = repostRecord
+
+    guard let repositoryDID = requestBody?.repository,
+          let repostCollection = requestBody?.collection,
+          let repostRecordKey = requestBody?.recordKey else {
+      throw ATRequestPrepareError.invalidRecord
+    }
+
+    try await atProtoKitInstance.deleteRecord(
+      repositoryDID: repositoryDID,
+      collection: repostCollection,
+      recordKey: repostRecordKey,
+      swapRecord: requestBody?.recordCID
+    )
+  }
+
+  fileprivate func resolveRecordIdentifierToQuery(
+    _ record: RecordIdentifier,
+    _ sessionURL: String,
+    _ repostRecord: inout ATProtoTools.RecordQuery?
+  ) async throws {
+    switch record {
+    case .recordQuery(let recordQuery):
+      do {
+        // Perform the fetch and validation based on recordQuery.
+        let output = try await atProtoKitInstance.getRepositoryRecord(
+          from: recordQuery.repository,
+          collection: recordQuery.collection,
+          recordKey: recordQuery.recordKey,
+          recordCID: recordQuery.recordCID,
+          pdsURL: sessionURL
+        )
+
+        let recordURI = "at://\(recordQuery.repository)/\(recordQuery.collection)/\(recordQuery.recordKey)"
+
+        guard output.recordURI == recordURI else {
+          throw ATRequestPrepareError.invalidRecord
+        }
+      } catch {
+        throw error
+      }
+
+    case .recordURI(let recordURI):
+      do {
+        // Perform the fetch and validation based on the parsed URI.
+        let parsedURI = try ATProtoTools().parseURI(recordURI)
+        let output = try await atProtoKitInstance.getRepositoryRecord(
+          from: parsedURI.repository,
+          collection: parsedURI.collection,
+          recordKey: parsedURI.recordKey,
+          recordCID: parsedURI.recordCID,
+          pdsURL: sessionURL
+        )
+
+        guard recordURI == output.recordURI else {
+          throw ATRequestPrepareError.invalidRecord
+        }
+
+        repostRecord = parsedURI
+      } catch {
+        throw error
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Description
I've added the ability to create a repost record, and delete it, using the same syntactic sugar as `createLikeRecord` and `deleteLikeRecord`.

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
I've basically copy and pasted the existing implementation for `createLikeRecord` and `deleteLikeRecord` into this file. Will look at adding the same implementations for more features, as well as de-duping the query logic.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Rhys Morgan]
- GitHub: [rhysm94]
- Bluesky: [rhysm.wales]
