### PR TITLE
Add createdAt to ProfileViewDetailedDefinition

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
@@ -225,6 +225,9 @@ extension AppBskyLexicon.Actor {
         /// The date the profile was last indexed. Optional.
         public let indexedAt: Date?
 
+        /// The date and time the profile was created. Optional.
+        public let createdAt: Date?
+
         /// The list of metadata relating to the requesting account's relationship with the subject
         /// account. Optional.
         public var viewer: ViewerStateDefinition?
@@ -238,7 +241,7 @@ extension AppBskyLexicon.Actor {
         public init(actorDID: String, actorHandle: String, displayName: String? = nil, description: String? = nil, avatarImageURL: URL? = nil,
                     bannerImageURL: URL? = nil, followerCount: Int? = nil, followCount: Int? = nil, postCount: Int? = nil,
                     associated: ProfileAssociatedDefinition?, joinedViaStarterPack: AppBskyLexicon.Graph.StarterpackRecord?, indexedAt: Date?,
-                    viewer: ViewerStateDefinition? = nil, labels: [ComAtprotoLexicon.Label.LabelDefinition]? = nil,
+                    createdAt: Date?, viewer: ViewerStateDefinition? = nil, labels: [ComAtprotoLexicon.Label.LabelDefinition]? = nil,
                     pinnedPost: ComAtprotoLexicon.Repository.StrongReference?) {
             self.actorDID = actorDID
             self.actorHandle = actorHandle
@@ -252,6 +255,7 @@ extension AppBskyLexicon.Actor {
             self.associated = associated
             self.joinedViaStarterPack = joinedViaStarterPack
             self.indexedAt = indexedAt
+            self.createdAt = createdAt
             self.viewer = viewer
             self.labels = labels
             self.pinnedPost = pinnedPost
@@ -272,6 +276,7 @@ extension AppBskyLexicon.Actor {
             self.joinedViaStarterPack = try container.decodeIfPresent(AppBskyLexicon.Graph.StarterpackRecord.self, forKey: .joinedViaStarterPack)
             self.associated = try container.decodeIfPresent(AppBskyLexicon.Actor.ProfileAssociatedDefinition.self, forKey: .associated)
             self.indexedAt = try decodeDateIfPresent(from: container, forKey: .indexedAt)
+            self.createdAt = try decodeDateIfPresent(from: container, forKey: .createdAt)
             self.viewer = try container.decodeIfPresent(AppBskyLexicon.Actor.ViewerStateDefinition.self, forKey: .viewer)
             self.labels = try container.decodeIfPresent([ComAtprotoLexicon.Label.LabelDefinition].self, forKey: .labels)
             self.pinnedPost = try container.decodeIfPresent(ComAtprotoLexicon.Repository.StrongReference.self, forKey: .pinnedPost)
@@ -299,6 +304,7 @@ extension AppBskyLexicon.Actor {
             try container.encodeIfPresent(self.associated, forKey: .associated)
             try container.encodeIfPresent(self.joinedViaStarterPack, forKey: .joinedViaStarterPack)
             try encodeDateIfPresent(self.indexedAt, with: &container, forKey: .indexedAt)
+            try encodeDateIfPresent(self.createdAt, with: &container, forKey: .createdAt)
             try container.encodeIfPresent(self.viewer, forKey: .viewer)
             try container.encodeIfPresent(self.labels, forKey: .labels)
             try container.encodeIfPresent(self.pinnedPost, forKey: .pinnedPost)
@@ -317,6 +323,7 @@ extension AppBskyLexicon.Actor {
             case joinedViaStarterPack
             case associated
             case indexedAt
+            case createdAt
             case viewer
             case labels
             case pinnedPost


### PR DESCRIPTION
## Description
As mentioned in #68 in `ProfileViewDetailedDefinition` the `createdAt` property is missing.
This PR addresses this and is adding the property to the struct.

## Linked Issues
#68

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation
- [x] Feature Enhancement

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.


## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Michael Freiwald]
- GitHub: [mfreiwald]
- Bluesky: [freiwald.dev]
- Email: [michael@freiwald.dev]
