### PR TITLE
Fix `RefreshSessionOutput` decoding in `refreshSession`

### DIFF
--- a/Sources/ATProtoKit/APIReference/SessionManager/ATProtocolConfiguration.swift
+++ b/Sources/ATProtoKit/APIReference/SessionManager/ATProtocolConfiguration.swift
@@ -317,7 +317,6 @@ public class ATProtocolConfiguration: SessionConfiguration {
         do {
             // Check if accessToken has anything inserted. If not, use the accessToken from the UserSession object.
             guard let sessionToken = accessToken ?? self.session?.accessToken else { return nil }
-            guard sessionToken == sessionToken else { return nil }
 
             let response = try await ATProtoKit().getSession(
                 by: sessionToken,
@@ -346,7 +345,6 @@ public class ATProtocolConfiguration: SessionConfiguration {
         do {
             // Check if accessToken has anything inserted. If not, use the accessToken from the UserSession object.
             guard let sessionToken = refreshToken ?? self.session?.refreshToken else { return nil }
-            guard sessionToken == sessionToken else { return nil }
 
             let response = try await ATProtoKit().refreshSession(
                 refreshToken: sessionToken,

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerRefreshSession.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerRefreshSession.swift
@@ -61,7 +61,7 @@ extension ComAtprotoLexicon.Server {
         public let did: String
 
         /// The DID document of the session. Optional.
-        public let didDocument: String?
+        public let didDocument: UnknownType?
 
         /// Indicates whether the user account is active. Optional.
         public let isActive: Bool?


### PR DESCRIPTION
## Description
The `refreshSession` call throws a `DecodingError` for `didDoc`
I changed the type of `didDocument` to `UnknownType` (same as in `CreateSessionOutput` and `GetSessionOutput`
No sure if `DIDDocument` would work too..

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Additional Notes
This is the decoding error:
```
 DecodingError
  ▿ typeMismatch : 2 elements
    - .0 : Swift.String
    ▿ .1 : Context
      ▿ codingPath : 1 element
        - 0 : CodingKeys(stringValue: "didDoc", intValue: nil)
      - debugDescription : "Expected to decode String but found a dictionary instead."
      - underlyingError : nil
```

This is the response from refreshSession:
```
{
  "did": "did:plc:abc123",
  "didDoc": {
    "@context": [
      "https://www.w3.org/ns/did/v1",
      "https://w3id.org/security/multikey/v1",
      "https://w3id.org/security/suites/secp256k1-2019/v1"
    ],
    "id": "did:plc:abc123",
    "alsoKnownAs": [
      "at://abc123.com"
    ],
    "verificationMethod": [
      {
        "id": "did:plc:abc123#atproto",
        "type": "Multikey",
        "controller": "did:plc:abc123",
        "publicKeyMultibase": "asdfasdfasdf"
      }
    ],
    "service": [
      {
        "id": "#atproto_pds",
        "type": "AtprotoPersonalDataServer",
        "serviceEndpoint": "https://splitgill.us-east.host.bsky.network"
      }
    ]
  },
  "handle": "abc123.com",
  "accessJwt": "accesstoken",
  "refreshJwt": "refreshtoken",
  "active": true
}

```

