### PR TITLE
Fix refresh session decoding didDocument as UnknownType

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerRefreshSession.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerRefreshSession.swift
@@ -61,7 +61,7 @@ extension ComAtprotoLexicon.Server {
         public let did: String
 
         /// The DID document of the session. Optional.
-        public let didDocument: String?
+        public let didDocument: UnknownType?
 
         /// Indicates whether the user account is active. Optional.
         public let isActive: Bool?


### PR DESCRIPTION
## Description
This PR proposes a decoding fix for the `RefreshSessionOutput` type, which was incorrectly attempting to decode the `didDoc`/`didDocument` property as `String?` rather than `UnknownType?`.


## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: Tony Arnold
- GitHub: tonyarnold
- Bluesky: @tonyarnold.com
