### PR TITLE
Fix type of `ratelimit-reset` header

### DIFF
--- a/Sources/ATProtoKit/Utilities/APIClientService.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientService.swift
@@ -345,10 +345,14 @@ public actor APIClientService {
                         let errorResponse = try JSONDecoder().decode(ATHTTPResponseError.self, from: data)
                         throw ATAPIError.payloadTooLarge(error: errorResponse)
                     case 429:
-                        let retryAfterHeader = httpResponse.allHeaderFields["ratelimit-reset"] as? TimeInterval
+                        let retryAfterValue: TimeInterval? = if let retryAfterHeader = httpResponse.allHeaderFields["ratelimit-reset"] as? String {
+                            TimeInterval(retryAfterHeader)
+                        } else {
+                            nil
+                        }
                         let errorResponse = try JSONDecoder().decode(ATHTTPResponseError.self, from: data)
 
-                        throw ATAPIError.tooManyRequests(error: errorResponse, retryAfter: retryAfterHeader)
+                        throw ATAPIError.tooManyRequests(error: errorResponse, retryAfter: retryAfterValue)
                     case 500:
                         let errorResponse = try JSONDecoder().decode(ATHTTPResponseError.self, from: data)
                         throw ATAPIError.internalServerError(error: errorResponse)


### PR DESCRIPTION
## Description
The `ratelimit-reset` header has a timestamp as its value. 
However, in the `tooManyRequests` 429 error, it is cast to a `TimeInterval` (Double), but header values are (always) Strings.
So it needs to be something like this:
```swift
TimeInterval(headers["ratelimit-reset"] as? String ?? "")
```

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.


## Additional Notes
This is an example output of the ratelimit headers:
```
ratelimit-limit: 3000
ratelimit-policy: 3000;w=300
ratelimit-remaining: 0
ratelimit-reset: 1734295297
```
