### PR TITLE
Derive only the language code from the Locale objects

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
@@ -267,7 +267,14 @@ extension ATProtoBluesky {
         }
 
         // Locales
-        let localeIdentifiers = locales.isEmpty ? nil : locales.map { $0.identifier }
+        let localeIdentifiers: [String]?
+        if #available(iOS 16, *) {
+            localeIdentifiers = locales.isEmpty ? nil : locales.compactMap {
+                $0.language.languageCode?.identifier
+            }
+        } else {
+            localeIdentifiers = locales.isEmpty ? nil : locales.compactMap { $0.languageCode }
+        }
 
         // Embed
         var resolvedEmbed: ATUnion.PostEmbedUnion? = nil


### PR DESCRIPTION
## Description
This updates the `createPostRecord` function to derive only language codes from Locales; previously it was deriving a full region-language code combo, which is incompatible with Bluesky's API.

## Linked Issues
#82 

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [ ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [ ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [ ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
