### PR TITLE
Add Reasons-Array to listNotifications parameter

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/ListNotifications.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/ListNotifications.swift
@@ -32,7 +32,7 @@ extension ATProtoKit {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func listNotifications(
-        with reason: String? = nil,
+        with reasons: [AppBskyLexicon.Notification.Notification.Reason]? = nil,
         limit: Int? = 50,
         isPriority: Bool?,
         cursor: String? = nil,
@@ -50,8 +50,10 @@ extension ATProtoKit {
 
         var queryItems = [(String, String)]()
 
-        if let reason {
-            queryItems.append(("reason", "\(reason)"))
+        if let reasons {
+            reasons.forEach { reason in
+                queryItems.append(("reasons[]", "\(reason.rawValue)"))
+            }
         }
 
         if let limit {


### PR DESCRIPTION
## Description
listNotifications only had a `reason` parameter, but the JSON schema requires an array of reasons
https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/notification/listNotifications.json

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x]  My code is able to build and run on my machine.
