### PR TITLE
Change language property from Locale to String for decoding

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
@@ -579,7 +579,7 @@ extension ATProtoBluesky {
                     imageData: caption.file
                 )
 
-                captionReferences.append(AppBskyLexicon.Embed.VideoDefinition.Caption(language: caption.language, fileBlob: blobReference.blob))
+                captionReferences.append(AppBskyLexicon.Embed.VideoDefinition.Caption(language: caption.language.identifier, fileBlob: blobReference.blob))
             }
         }
 

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedVideo.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedVideo.swift
@@ -78,7 +78,7 @@ extension AppBskyLexicon.Embed {
             public let type: String = "app.bsky.embed.video#caption"
 
             /// The language the captions are written in.
-            public let language: Locale
+            public let language: String
 
             /// The caption file itself.
             ///


### PR DESCRIPTION
## Description
A string like "en" doesn't decode to Swift `Locale` out-of-the-box.
That's why I changed the language property of the Video#Caption to `String`.

I'm not sure if there are other Models with Locale instead of a plain String for language properties.

See this small example:
```swift
import Foundation

struct Caption: Codable {
    let lang: Locale
}

let json = "{\"lang\": \"en\"}"
let data = json.data(using: .utf8)!

do {
    let caption = try JSONDecoder().decode(Caption.self, from: data)
} catch {
    print(error)
    /*
     typeMismatch(Swift.Dictionary<Swift.String, Any>, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "lang", intValue: nil)], debugDescription: "Expected to decode Dictionary<String, Any> but found a string instead.", underlyingError: nil))
     */
}
```

## Linked Issues
Link any related issues here. Format: `#[issue number]`

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.
