### PR TITLE
Defeat the final boss in job states

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Video/AppBskyVideoDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Video/AppBskyVideoDefs.swift
@@ -65,6 +65,9 @@ extension AppBskyLexicon.Video {
 
             /// The job is currently scanning.
             case jobStateScanning = "JOB_STATE_SCANNING"
+            
+            /// The job is scanned.
+            case jobStateScanned = "JOB_STATE_SCANNED"
 
             /// The job is completed processing.
             case jobStateCompleted = "JOB_STATE_COMPLETED"


### PR DESCRIPTION
## Description
This adds the last missing job state for video uploads: "JOB_STATE_SCANNED"

## Linked Issues
#97 

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [ ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [ ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [ ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
