### PR TITLE
Remove `type` from StarterPackViewBasicDefinition

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Graph/AppBskyGraphDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Graph/AppBskyGraphDefs.swift
@@ -352,11 +352,6 @@ extension AppBskyLexicon.Graph {
     /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/graph/defs.json
     public struct StarterPackViewBasicDefinition: Sendable, Codable, Equatable, Hashable {
 
-        /// The identifier of the lexicon.
-        ///
-        /// - Warning: The value must not change.
-        public let type: String = "app.bsky.graph.defs#starterPackViewBasic"
-
         /// The URI of the starter pack.
         public let uri: String
 
@@ -389,11 +384,6 @@ extension AppBskyLexicon.Graph {
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
 
-            let decodedType = try container.decode(String.self, forKey: .type)
-            if decodedType != type {
-                throw DecodingError.typeMismatch(ListViewDefinition.self, .init(codingPath: [CodingKeys.type], debugDescription: "type did not match expected type \(type)"))
-            }
-          
             self.uri = try container.decode(String.self, forKey: CodingKeys.uri)
             self.cid = try container.decode(String.self, forKey: .cid)
             self.record = try container.decode(UnknownType.self, forKey: .record)
@@ -420,7 +410,6 @@ extension AppBskyLexicon.Graph {
         }
 
         enum CodingKeys: String, CodingKey {
-            case type = "$type"
             case uri
             case cid
             case record


### PR DESCRIPTION
## Description
Decoding of `ProfileViewDetailedDefinition` with `joinedViaStarterPack` still fails as mentioned in https://github.com/MasterJ93/ATProtoKit/issues/109

I removed the type property in `StarterPackViewBasicDefinition` because it is not part of the official JSON schema.

## Linked Issues
#109 

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.


## Additional Notes
See the last comment in the Issue

