### PR TITLE
Fallback for refreshSession’s pdsURL

### DIFF
--- a/Sources/ATProtoKit/APIReference/SessionManager/ATProtocolConfiguration.swift
+++ b/Sources/ATProtoKit/APIReference/SessionManager/ATProtocolConfiguration.swift
@@ -486,7 +486,7 @@ public class ATProtocolConfiguration: SessionConfiguration {
                 isActive: response.isActive,
                 status: status,
                 serviceEndpoint: serviceEndpoint,
-                pdsURL: session?.pdsURL ?? nil,
+                pdsURL: session?.pdsURL ?? (self.pdsURL ?? nil),
                 logger: await ATProtocolConfiguration.getLogger(),
                 maxRetryCount: self.maxRetryCount,
                 retryTimeDelay: self.retryTimeDelay


### PR DESCRIPTION
## Description
I was doing some work on my auth implementation in Croissant, and I came across something that's either a bug (which this PR fixes) or I'm holding it wrong. I honestly think it could break either way. 😬 

I'm now saving the session's accessToken and refreshToken in the keychain, and instead of authenticating, I'm using the refreshSession call. However, I noticed that the resulting session had a nil value for pdsURL. This obviously prevents any subsequent framework calls from working. 

My fix is a one-liner in the refreshToken call to fallback on the config object's pdsURL value if the session doesn't have it, before setting it to nil. This should have no effect on callers who are "holding it right".

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [ ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [ ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [ ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
