### PR TITLE
Parse for links, *then* clip the post text

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
@@ -273,10 +273,7 @@ extension ATProtoBluesky {
             throw ATRequestPrepareError.invalidPDS
         }
 
-        // Truncate the number of characters to 300.
-        let postText = text.truncated(toLength: 300)
-
-        var facets = await ATFacetParser.parseFacets(from: postText, pdsURL: session.pdsURL ?? "https://bsky.social")
+        var facets = await ATFacetParser.parseFacets(from: text, pdsURL: session.pdsURL ?? "https://bsky.social")
         if let inlineFacets {
             for (url, start, end) in inlineFacets {
                 do {
@@ -287,6 +284,9 @@ extension ATProtoBluesky {
                 }
             }
         }
+        
+        // Truncate the number of characters to 300.
+        let postText = text.truncated(toLength: 300)
 
         // Replies
         // Validate the reply reference if provided.


### PR DESCRIPTION
## Description
My Bluesky posting client estimates character count by converting hyperlinks to their final maximum character counts. Bluesky removes the scheme from the URL and truncates to 32 chars. However, in `createPostRecord()`, the post text is clipped to 300 characters before the facet parsing occurs. In the event of a post that, say, ends with a URL, that can get clipped before it gets parsed. Here's an example of a post created by one of my customers, where the final link is truncated in the post text:

https://bsky.app/profile/adfc-gd.bsky.social/post/3lkfygf5afd2a

To remedy, I have swapped the order of operations: first the post text is parsed, making sure facets are generated for the post. Then the text is truncated. Here's that same post under this new method:

https://bsky.app/profile/did:plc:vepis2bllryitqskja5fmwiw/post/3lkgtrtqkj22v

This will make my users happy. :-) 

## Linked Issues
Sorry, I just found this and went for it.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [ ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [ ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [ ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
