### PR TITLE
Handle URL truncation in posts to achieve accurate length

### DIFF
--- a/Sources/ATProtoKit/Utilities/ATFacetParser.swift
+++ b/Sources/ATProtoKit/Utilities/ATFacetParser.swift
@@ -97,8 +97,10 @@ public class ATFacetParser {
     }
     
     /// Replaces URL text in the original string with a truncated version used for display in Bluesky.
-    /// This shortens each URL to exclude the scheme and limit to 32 characters total.
-    /// The replacement uses byte ranges, so the function processes from the end of the string backward.
+    /// 
+    /// - Parameter text: The post's text.
+    /// - Returns: A tuple containing the updated plain text and an array of link facets.
+    ///   Each link facet represents a detected URL within the text, along with its start and end positions.
     public static func truncateAndReplaceLinks(in text: String) -> (text: String, updatedLinkFacets: [(url: URL, start: Int, end: Int)]) {
         var result = ""
         var updatedFacets: [(url: URL, start: Int, end: Int)] = []


### PR DESCRIPTION
## Description
Bluesky truncates URLs within posts using this simple algorithm: 
* Nip off the scheme "http://" or "https://"
* Clamp the length of the URL text to 32 characters

My posting client, Croissant, respects this logic when calculating the post length as users type their posts in the composer. However, during posting in ATProtoKit, the post text will be truncated to 300 characters, based on the full length of the URLs within. Here's an example post from Croissant that a user complained about:

https://bsky.app/profile/filippo.abyssdomain.expert/post/3lmhaj5zma32u
<img width="589" alt="Screenshot 2025-04-11 at 8 46 00 PM" src="https://github.com/user-attachments/assets/de6e6707-7c93-4d00-91df-8f182422e970" />

This post has two URLs, and the second is clipped considerably because while the length of the resolved text was fine, it got clipped because the first URL is counting towards the total.

This PR does a fair bit of wrangling with the post text in order to:

* replace URLs in the post text with their shortened versions (adding an ellipsis on the end of truncated URLs)
* update the array of facets to respect their new URL lengths.

The result, using this code posting the same content from my test Bluesky account:

https://bsky.app/profile/did:plc:vepis2bllryitqskja5fmwiw/post/3lmlc4u3fak2i
<img width="590" alt="Screenshot 2025-04-11 at 8 48 32 PM" src="https://github.com/user-attachments/assets/ea0a30e4-8cea-484f-b308-a11ff3177226" />

Mmmmm. Proper.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [ ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [ ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [ ] My code is able to build and run on my machine.
