### PR TITLE
Fix ListRepositoriesOutput and ListRepositoriesByCollectionOutput incorrect CodingKeys

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Sync/ComAtprotoSyncListRepos.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Sync/ComAtprotoSyncListRepos.swift
@@ -61,7 +61,7 @@ extension ComAtprotoLexicon.Sync {
 
         enum CodingKeys: String, CodingKey {
             case cursor
-            case repositories = "repo"
+            case repositories = "repos"
         }
 
         // Enums

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Sync/ComAtprotoSyncListReposByCollection.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Sync/ComAtprotoSyncListReposByCollection.swift
@@ -44,5 +44,10 @@ extension ComAtprotoLexicon.Sync {
 
         /// An array of repositories.
         public let repositories: [ListRepositoriesByCollection.Repository]
+
+        enum CodingKeys: String, CodingKey {
+            case cursor
+            case repositories = "repos"
+        }
     }
 }


### PR DESCRIPTION
## Description

A quick fix for the `com.atproto.sync.listRepos` and `com.atproto.sync.listReposByCollection` responses.

## Linked Issues
N/A

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes

No docs changes here
