### PR TITLE
Mute and Unmute need to have application/json contentType

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/MuteActor.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/MuteActor.swift
@@ -44,7 +44,6 @@ extension ATProtoKit {
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
-                contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/UnmuteActor.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/UnmuteActor.swift
@@ -44,7 +44,6 @@ extension ATProtoKit {
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
-                contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
 


### PR DESCRIPTION
## Description
Mute and Unmute requests need to have `application/json` for `ContentType`.
Requests are failing because of wrong `contentTypeValue` in request.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

