### PR TITLE
Put a 25-deep limit on ThreadViewPostParentUnion decoding

### DIFF
--- a/Sources/ATProtoKit/Utilities/CodingUserInfoKey+DecodingDepth.swift
+++ b/Sources/ATProtoKit/Utilities/CodingUserInfoKey+DecodingDepth.swift
@@ -1,0 +1,39 @@
+//
+//  CodingUserInfoKey+DecodingDepth.swift
+//
+
+import Foundation
+
+public extension CodingUserInfoKey {
+    /// A key used to access the recursion depth tracker in `userInfo` during decoding.
+    static let decodingDepthState = CodingUserInfoKey(rawValue: "com.atprotokit.decodingDepthState")!
+}
+
+/// A class to manage the recursion depth during decoding.
+public final class DecodingDepthState: @unchecked Sendable {
+    private let lock = NSLock() 
+    private var _internalCurrentDepth: Int = 0 
+
+    /// The current recursion depth.
+    public var currentDepth: Int {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _internalCurrentDepth
+        }
+        set {
+            lock.lock()
+            _internalCurrentDepth = newValue
+            lock.unlock()
+        }
+    }
+    /// The maximum allowed recursion depth.
+    public let maxDepth: Int 
+
+    /// Initializes a new decoding state.
+    /// - Parameter maxDepth: The maximum depth to allow before stopping recursion. Defaults to 25.
+    public init(maxDepth: Int = 25) {
+        self.maxDepth = maxDepth
+        // _internalCurrentDepth is initialized to 0.
+    }
+}


### PR DESCRIPTION
## Description
Please see https://github.com/MasterJ93/ATProtoKit/issues/162 for details about this

## Linked Issues
Link any related issues here. Format: `#[issue number]`

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [ ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [ ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [ ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
