### PR TITLE
Use app.bsky.embed.external for StatusRecord (not #view version)

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorStatus.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorStatus.swift
@@ -121,12 +121,12 @@ extension AppBskyLexicon.Actor {
         public enum EmbedUnion: Sendable, Codable, Equatable, Hashable {
 
             /// An external embed view.
-            case externalView(AppBskyLexicon.Embed.ExternalDefinition.View)
+            case externalView(AppBskyLexicon.Embed.ExternalDefinition)
 
             public init(from decoder: any Decoder) throws {
                 let container = try decoder.singleValueContainer()
 
-                if let value = try? container.decode(AppBskyLexicon.Embed.ExternalDefinition.View.self) {
+                if let value = try? container.decode(AppBskyLexicon.Embed.ExternalDefinition.self) {
                     self = .externalView(value)
                 } else {
                     throw DecodingError.typeMismatch(


### PR DESCRIPTION
## Description
StatusRecord should use "app.bsky.embed.external" for embedUntion externalView and not "app.bsky.embed.external#view"

## Linked Issues
https://github.com/MasterJ93/ATProtoKit/issues/158

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

