### PR TITLE
Update APIClientService to be not a Singleton

### DIFF
--- a/API_GUIDELINES.md
+++ b/API_GUIDELINES.md
@@ -419,10 +419,10 @@ guard session != nil,
     ```swift
     let queryURL: URL
     ```
-    - Inside the `do` block, set the value of `queryURL` to `APIClientService.setQueryItems()`, inserting `requestURL` and `queryItems` respectively. Each parameter, and the closing paranthesis, must have a separate line.
+    - Inside the `do` block, set the value of `queryURL` to `apiClientService.setQueryItems()`, inserting `requestURL` and `queryItems` respectively. Each parameter, and the closing paranthesis, must have a separate line.
     ```swift
     do {
-    queryURL = try APIClientService.setQueryItems(
+    queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
     )

--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
@@ -610,7 +610,7 @@ extension ATProtoBluesky {
         if let captions = captions {
             print("Beginning caption collection...")
             for caption in captions {
-                let blobReference = try await ATProtoKit(canUseBlueskyRecords: false).uploadBlob(
+                let blobReference = try await atProtoKitInstance.uploadBlob(
                     pdsURL: pdsURL,
                     accessToken: accessToken,
                     filename: "\(ATProtoTools().generateRandomString())_caption.vtt",

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AddMemberAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AddMemberAsAdmin.swift
@@ -50,14 +50,14 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ToolsOzoneLexicon.Team.MemberDefinition.self

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AddValuesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AddValuesAsAdmin.swift
@@ -39,7 +39,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -47,7 +47,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AdminSearchAccountsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AdminSearchAccountsAsAdmin.swift
@@ -67,19 +67,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Admin.SearchAccountsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/CreateCommunicationTemplateAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/CreateCommunicationTemplateAsAdmin.swift
@@ -60,14 +60,14 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ToolsOzoneLexicon.Communication.TemplateViewDefinition.self

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteAccountAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteAccountAsAdmin.swift
@@ -43,7 +43,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -51,7 +51,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteCommunicationTemplateAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteCommunicationTemplateAsAdmin.swift
@@ -42,7 +42,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -50,7 +50,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteMemberAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteMemberAsAdmin.swift
@@ -43,7 +43,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -51,7 +51,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteSetAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteSetAsAdmin.swift
@@ -41,7 +41,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -49,7 +49,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ToolsOzoneLexicon.Set.DeleteSetOutput.self

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteValuesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteValuesAsAdmin.swift
@@ -46,7 +46,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -54,7 +54,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ToolsOzoneLexicon.Set.DeleteSetOutput.self

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DisableAccountInvitesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DisableAccountInvitesAsAdmin.swift
@@ -49,7 +49,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -57,7 +57,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DisableInviteCodesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DisableInviteCodesAsAdmin.swift
@@ -49,13 +49,13 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(forRequest: requestURL,
+            let request = apiClientService.createRequest(forRequest: requestURL,
                                                          andMethod: .post,
                                                          acceptValue: nil,
                                                          contentTypeValue: "'application/json",
                                                          authorizationValue: "Bearer \(accessToken)")
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/EmitEventAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/EmitEventAsAdmin.swift
@@ -57,14 +57,14 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ToolsOzoneLexicon.Moderation.ModerationEventViewDefinition.self

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/EnableAccountInvitesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/EnableAccountInvitesAsAdmin.swift
@@ -52,7 +52,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -60,7 +60,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/FindCorrelationAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/FindCorrelationAsAdmin.swift
@@ -43,19 +43,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Signature.FindCorrelationOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/FindRelatedAccountsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/FindRelatedAccountsAsAdmin.swift
@@ -63,19 +63,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Signature.FindRelatedAccountsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetAccountInfoAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetAccountInfoAsAdmin.swift
@@ -48,19 +48,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Admin.AccountViewDefinition.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetAccountInfosAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetAccountInfosAsAdmin.swift
@@ -46,19 +46,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Admin.GetAccountInfosOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetConfigAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetConfigAsAdmin.swift
@@ -40,19 +40,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Server.GetConfigurationOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetInviteCodesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetInviteCodesAsAdmin.swift
@@ -60,19 +60,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Admin.GetInviteCodesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetModerationEventAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetModerationEventAsAdmin.swift
@@ -46,19 +46,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Moderation.EventViewDetailDefinition.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRecordAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRecordAsAdmin.swift
@@ -52,19 +52,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Moderation.RecordViewDetailDefinition.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetReporterStats.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetReporterStats.swift
@@ -45,19 +45,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Moderation.GetReporterStatsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRepositoriesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRepositoriesAsAdmin.swift
@@ -43,19 +43,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Moderation.GetRepositoriesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRepositoryAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRepositoryAsAdmin.swift
@@ -43,19 +43,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Moderation.RepositoryViewDetailDefinition.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetSubjectStatusAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetSubjectStatusAsAdmin.swift
@@ -55,19 +55,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Admin.GetSubjectStatusOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetSubjectsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetSubjectsAsAdmin.swift
@@ -43,19 +43,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Moderation.GetSubjectsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetValuesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetValuesAsAdmin.swift
@@ -57,19 +57,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Set.GetValuesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListCommunicationTemplatesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListCommunicationTemplatesAsAdmin.swift
@@ -39,14 +39,14 @@ extension ATProtoAdmin {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Communication.ListTemplatesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListMembersAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListMembersAsAdmin.swift
@@ -78,19 +78,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Team.ListMembersOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListOptionsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListOptionsAsAdmin.swift
@@ -74,19 +74,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Setting.ListOptionsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ModerationGetRecordsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ModerationGetRecordsAsAdmin.swift
@@ -42,19 +42,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Moderation.GetRecordsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QueryModerationEventsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QueryModerationEventsAsAdmin.swift
@@ -199,19 +199,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Moderation.QueryEventsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QueryModerationStatusesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QueryModerationStatusesAsAdmin.swift
@@ -305,19 +305,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Moderation.QueryStatusesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QuerySetsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QuerySetsAsAdmin.swift
@@ -74,19 +74,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Set.QuerySetsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/RemoveOptionsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/RemoveOptionsAsAdmin.swift
@@ -39,7 +39,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -47,7 +47,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SearchRepositoriesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SearchRepositoriesAsAdmin.swift
@@ -65,19 +65,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Admin.SearchRepositoriesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SendEmailAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SendEmailAsAdmin.swift
@@ -59,7 +59,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -67,7 +67,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Admin.SendEmailOutput.self

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SignatureSearchAccountsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SignatureSearchAccountsAsAdmin.swift
@@ -61,19 +61,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Signature.SearchAccountsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneHostingGetAccountHistoryMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneHostingGetAccountHistoryMethod.swift
@@ -67,19 +67,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Hosting.GetAccountHistoryOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneListVerificationsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneListVerificationsMethod.swift
@@ -97,19 +97,19 @@ extension ATProtoAdmin {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ToolsOzoneLexicon.Verification.ListVerificationsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneVerificationRevokeVerificationsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneVerificationRevokeVerificationsMethod.swift
@@ -48,7 +48,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -56,7 +56,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ToolsOzoneLexicon.Verification.RevokeVerificationsOutput.self

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneVerificationsGrantVerificationsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneVerificationsGrantVerificationsMethod.swift
@@ -41,14 +41,14 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ToolsOzoneLexicon.Verification.GrantVerificationsOutput.self

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountEmailAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountEmailAsAdmin.swift
@@ -49,7 +49,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -57,7 +57,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountHandleAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountHandleAsAdmin.swift
@@ -49,7 +49,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -57,7 +57,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountPasswordAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountPasswordAsAdmin.swift
@@ -46,7 +46,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -54,7 +54,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountSigningKey.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountSigningKey.swift
@@ -40,7 +40,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -48,7 +48,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateCommunicationTemplateAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateCommunicationTemplateAsAdmin.swift
@@ -66,14 +66,14 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ToolsOzoneLexicon.Communication.TemplateViewDefinition.self

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateMemberAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateMemberAsAdmin.swift
@@ -53,14 +53,14 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(request,
+            let response = try await apiClientService.sendRequest(request,
                                                                          withEncodingBody: requestBody,
                                                                          decodeTo: ToolsOzoneLexicon.Team.MemberDefinition.self
             )

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateSubjectStatusAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateSubjectStatusAsAdmin.swift
@@ -53,14 +53,14 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Admin.UpdateSubjectStatusOutput.self

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpsertOptionAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpsertOptionAsAdmin.swift
@@ -52,14 +52,14 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ToolsOzoneLexicon.Setting.UpsertOptionOutput.self

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpsertSetAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpsertSetAsAdmin.swift
@@ -46,7 +46,7 @@ extension ATProtoAdmin {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -54,7 +54,7 @@ extension ATProtoAdmin {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ToolsOzoneLexicon.Set.SetViewDefinition.self

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyActorPreferencesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyActorPreferencesMethod.swift
@@ -40,7 +40,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -48,7 +48,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedDescribeFeedGeneratorMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedDescribeFeedGeneratorMethod.swift
@@ -34,14 +34,14 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: nil,
                 contentTypeValue: "application/json",
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.DescribeFeedGeneratorOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetActorFeedsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetActorFeedsMethod.swift
@@ -61,19 +61,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetActorFeedsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetActorLikesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetActorLikesMethod.swift
@@ -66,19 +66,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetActorLikesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetAuthorFeedMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetAuthorFeedMethod.swift
@@ -80,19 +80,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetAuthorFeedOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedGeneratorMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedGeneratorMethod.swift
@@ -46,19 +46,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetFeedGeneratorOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedGeneratorsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedGeneratorsMethod.swift
@@ -46,19 +46,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetFeedGeneratorsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedMethod.swift
@@ -60,19 +60,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetFeedOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedSkeletonMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedSkeletonMethod.swift
@@ -56,19 +56,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: nil,
                 contentTypeValue: "application/json",
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetFeedSkeletonOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetLikesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetLikesMethod.swift
@@ -67,19 +67,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetLikesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetActorStarterPacksMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetActorStarterPacksMethod.swift
@@ -61,19 +61,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetActorStarterPacksOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetBlocksMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetBlocksMethod.swift
@@ -57,19 +57,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetBlocksOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetFollowersMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetFollowersMethod.swift
@@ -61,19 +61,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: authorizationValue
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetFollowersOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetFollowsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetFollowsMethod.swift
@@ -61,19 +61,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: authorizationValue
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetFollowsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetKnownFollowersMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetKnownFollowersMethod.swift
@@ -59,19 +59,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetKnownFollowersOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyLabelerGetServicesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyLabelerGetServicesMethod.swift
@@ -44,19 +44,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request, decodeTo:
                 AppBskyLexicon.Labeler.GetServicesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetPopularFeedGeneratorsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetPopularFeedGeneratorsMethod.swift
@@ -65,19 +65,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetPopularFeedGeneratorsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedFeedsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedFeedsMethod.swift
@@ -48,19 +48,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetSuggestedFeedsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedFeedsSkeletonMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedFeedsSkeletonMethod.swift
@@ -58,19 +58,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetSuggestedFeedsSkeletonOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedStarterPacksMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedStarterPacksMethod.swift
@@ -48,19 +48,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetSuggestedStarterPacksOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedStarterPacksSkeletonMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedStarterPacksSkeletonMethod.swift
@@ -58,19 +58,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetSuggestedStarterPacksSkeletonOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedUsersMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedUsersMethod.swift
@@ -57,19 +57,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetSuggestedUsersOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedUsersSkeletonMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedUsersSkeletonMethod.swift
@@ -60,19 +60,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetSuggestedUsersSkeletonOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTrendsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTrendsMethod.swift
@@ -48,19 +48,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetTrendsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTrendsSkeletonMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTrendsSkeletonMethod.swift
@@ -58,19 +58,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetTrendsSkeletonOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyVideoGetJobStatusMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyVideoGetJobStatusMethod.swift
@@ -38,19 +38,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(serviceToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Video.GetJobStatusOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetList.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetList.swift
@@ -61,19 +61,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetListOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetListBlocks.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetListBlocks.swift
@@ -57,19 +57,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetListBlocksOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetListFeed.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetListFeed.swift
@@ -59,19 +59,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetListFeedOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetListMutes.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetListMutes.swift
@@ -57,19 +57,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetListMutesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetLists.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetLists.swift
@@ -61,19 +61,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetListsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetMutes.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetMutes.swift
@@ -57,19 +57,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetMutesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetPostThread.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetPostThread.swift
@@ -61,19 +61,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: authorizationValue
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetPostThreadOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetPosts.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetPosts.swift
@@ -51,19 +51,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetPostsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetPreferences.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetPreferences.swift
@@ -37,14 +37,14 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Actor.GetPreferencesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetProfile.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetProfile.swift
@@ -53,18 +53,18 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 contentTypeValue: nil,
                 authorizationValue: authorizationValue
             )
-            let result = try await APIClientService.shared.sendRequest(
+            let result = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Actor.ProfileViewDetailedDefinition.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetProfiles.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetProfiles.swift
@@ -55,18 +55,18 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 contentTypeValue: nil,
                 authorizationValue: authorizationValue
             )
-            let result = try await APIClientService.shared.sendRequest(
+            let result = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Actor.GetProfilesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetQuotes.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetQuotes.swift
@@ -67,19 +67,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetQuotesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetRelationships.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetRelationships.swift
@@ -53,19 +53,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetRelationshipsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetRepostedBy.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetRepostedBy.swift
@@ -67,19 +67,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetRepostedByOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetStarterPack.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetStarterPack.swift
@@ -40,19 +40,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetStarterPackOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetStarterPacks.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetStarterPacks.swift
@@ -43,19 +43,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetStarterPacksOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetSuggestedFeeds.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetSuggestedFeeds.swift
@@ -56,19 +56,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetSuggestedFeedsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetSuggestedFollowsByActor.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetSuggestedFollowsByActor.swift
@@ -46,19 +46,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.GetSuggestedFollowsByActorOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetSuggestions.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetSuggestions.swift
@@ -55,19 +55,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: nil,
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Actor.GetSuggestionsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetSuggestionsSkeleton.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetSuggestionsSkeleton.swift
@@ -76,19 +76,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetSuggestionsSkeletonOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetTaggedSuggestions.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetTaggedSuggestions.swift
@@ -35,14 +35,14 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetTaggedSuggestionsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetTimeline.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetTimeline.swift
@@ -68,19 +68,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.GetTimelineOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetUnreadCount.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetUnreadCount.swift
@@ -55,19 +55,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Notification.GetUnreadCountOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/GetUploadLimits.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/GetUploadLimits.swift
@@ -36,19 +36,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(serviceToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Video.GetUploadLimitsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/ListNotifications.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/ListNotifications.swift
@@ -83,19 +83,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Notification.ListNotificationsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/MuteActor.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/MuteActor.swift
@@ -40,14 +40,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/MuteActorList.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/MuteActorList.swift
@@ -40,7 +40,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -48,7 +48,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/MuteThread.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/MuteThread.swift
@@ -41,7 +41,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -49,7 +49,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/NotificationPutPreferences.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/NotificationPutPreferences.swift
@@ -40,7 +40,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -48,7 +48,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/RegisterPush.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/RegisterPush.swift
@@ -52,7 +52,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -60,7 +60,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchActors.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchActors.swift
@@ -65,18 +65,18 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Actor.SearchActorsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchActorsSkeleton.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchActorsSkeleton.swift
@@ -72,19 +72,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.SearchActorsSkeletonOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchActorsTypeahead.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchActorsTypeahead.swift
@@ -68,18 +68,18 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 authorizationValue: authorizationValue
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Actor.SearchActorsTypeaheadOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchPosts.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchPosts.swift
@@ -125,19 +125,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Feed.SearchPostsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchPostsSkeleton.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchPostsSkeleton.swift
@@ -121,19 +121,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.SearchPostsSkeletonOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchStarterPacks.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/SearchStarterPacks.swift
@@ -57,18 +57,18 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Graph.SearchStarterPacksOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/SendInteractions.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/SendInteractions.swift
@@ -46,14 +46,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: AppBskyLexicon.Feed.SendInteractionsOutput.self

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/UnmuteActor.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/UnmuteActor.swift
@@ -40,14 +40,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/UnmuteActorList.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/UnmuteActorList.swift
@@ -40,7 +40,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -48,7 +48,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/UnmuteThread.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/UnmuteThread.swift
@@ -40,7 +40,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -48,7 +48,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/UnspeccedGetConfig.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/UnspeccedGetConfig.swift
@@ -43,19 +43,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetConfigOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/UnspeccedGetTrendingTopics.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/UnspeccedGetTrendingTopics.swift
@@ -61,19 +61,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.GetTrendingTopicsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/UnspeccedSearchStarterPackSkeleton.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/UnspeccedSearchStarterPackSkeleton.swift
@@ -63,18 +63,18 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: AppBskyLexicon.Unspecced.SearchStarterPackSkeletonOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/UpdateSeen.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/UpdateSeen.swift
@@ -41,7 +41,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -49,7 +49,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/UploadVideo.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/UploadVideo.swift
@@ -62,12 +62,12 @@ extension ATProtoKit {
 
         while attempts < maxRetryCount {
             do {
-                let queryURL = try APIClientService.setQueryItems(
+                let queryURL = try apiClientService.setQueryItems(
                     for: requestURL,
                     with: queryItems
                 )
 
-                var request = await APIClientService.createRequest(
+                var request = apiClientService.createRequest(
                     forRequest: queryURL,
                     andMethod: .post,
                     acceptValue: "application/json",
@@ -77,7 +77,7 @@ extension ATProtoKit {
                 request.httpBody = requestBody.video
                 print("requestURL: \(requestURL)")
 
-                let response = try await APIClientService.shared.sendRequest(
+                let response = try await apiClientService.sendRequest(
                     request,
                     decodeTo: AppBskyLexicon.Video.JobStatusDefinition.self
                 )

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/AcceptConversation.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/AcceptConversation.swift
@@ -38,7 +38,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -47,7 +47,7 @@ extension ATProtoBlueskyChat {
                 isRelatedToBskyChat: true
             )
 
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ChatBskyLexicon.Conversation.AcceptConversationOutput.self

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoAddReactionMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoAddReactionMethod.swift
@@ -51,7 +51,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -60,7 +60,7 @@ extension ATProtoBlueskyChat {
                 isRelatedToBskyChat: true
             )
 
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ChatBskyLexicon.Conversation.AddReactionOutput.self

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoRemoveReactionMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoRemoveReactionMethod.swift
@@ -51,7 +51,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -60,7 +60,7 @@ extension ATProtoBlueskyChat {
                 isRelatedToBskyChat: true
             )
 
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ChatBskyLexicon.Conversation.RemoveReactionOutput.self

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatDeleteAccount.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatDeleteAccount.swift
@@ -35,7 +35,7 @@ extension ATProtoBlueskyChat {
         let requestBody = ChatBskyLexicon.Actor.DeleteAccount()
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -44,7 +44,7 @@ extension ATProtoBlueskyChat {
                 isRelatedToBskyChat: true
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatDeleteMessageForSelf.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatDeleteMessageForSelf.swift
@@ -44,7 +44,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -52,7 +52,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ChatBskyLexicon.Conversation.DeletedMessageViewDefinition.self

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatExportAccountData.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatExportAccountData.swift
@@ -34,7 +34,7 @@ extension ATProtoBlueskyChat {
 
         do {
             // TODO: Figure out what exactly should be done here.
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/jsonl",
@@ -43,7 +43,7 @@ extension ATProtoBlueskyChat {
                 isRelatedToBskyChat: true
             )
 
-            let response = try await APIClientService.shared.sendRequest(request)
+            let response = try await apiClientService.sendRequest(request)
 
             return response
         } catch {

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetActorMetadata.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetActorMetadata.swift
@@ -46,12 +46,12 @@ extension ATProtoBlueskyChat {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -59,7 +59,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ChatBskyLexicon.Moderation.GetActorMetadataOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetConvo.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetConvo.swift
@@ -40,12 +40,12 @@ extension ATProtoBlueskyChat {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -53,7 +53,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ChatBskyLexicon.Conversation.GetConversationOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetConvoForMembers.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetConvoForMembers.swift
@@ -45,12 +45,12 @@ extension ATProtoBlueskyChat {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -58,7 +58,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ChatBskyLexicon.Conversation.GetConversationForMembersOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetLog.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetLog.swift
@@ -43,12 +43,12 @@ extension ATProtoBlueskyChat {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -56,7 +56,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ChatBskyLexicon.Conversation.GetLogOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetMessageContext.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetMessageContext.swift
@@ -66,12 +66,12 @@ extension ATProtoBlueskyChat {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -79,7 +79,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ChatBskyLexicon.Moderation.GetMessageContextOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetMessages.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatGetMessages.swift
@@ -51,12 +51,12 @@ extension ATProtoBlueskyChat {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -64,7 +64,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ChatBskyLexicon.Conversation.GetMessagesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatLeaveConvo.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatLeaveConvo.swift
@@ -38,7 +38,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -46,7 +46,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ChatBskyLexicon.Conversation.LeaveConversationOutput.self

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatListConvos.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatListConvos.swift
@@ -58,12 +58,12 @@ extension ATProtoBlueskyChat {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -71,7 +71,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(request,
+            let response = try await apiClientService.sendRequest(request,
                 decodeTo: ChatBskyLexicon.Conversation.ListConversationsOutput.self)
 
             return response

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatMuteConvo.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatMuteConvo.swift
@@ -38,7 +38,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -46,7 +46,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ChatBskyLexicon.Conversation.MuteConversationOutput.self

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatSendMessage.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatSendMessage.swift
@@ -46,7 +46,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -54,7 +54,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ChatBskyLexicon.Conversation.MessageViewDefinition.self

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatSendMessageBatch.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatSendMessageBatch.swift
@@ -42,7 +42,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -50,7 +50,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ChatBskyLexicon.Conversation.SendMessageBatchOutput.self

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatUnmuteConvo.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatUnmuteConvo.swift
@@ -38,7 +38,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -46,7 +46,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ChatBskyLexicon.Conversation.UnmuteConversationOutput.self

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatUpdateActorAccess.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatUpdateActorAccess.swift
@@ -49,7 +49,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: nil,
@@ -58,7 +58,7 @@ extension ATProtoBlueskyChat {
                 isRelatedToBskyChat: true
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatUpdateRead.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatUpdateRead.swift
@@ -44,7 +44,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -52,7 +52,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ChatBskyLexicon.Conversation.UpdateReadOutput.self

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/GetConversationAvailability.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/GetConversationAvailability.swift
@@ -46,12 +46,12 @@ extension ATProtoBlueskyChat {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -59,7 +59,7 @@ extension ATProtoBlueskyChat {
                 authorizationValue: "Bearer \(accessToken)",
                 isRelatedToBskyChat: true
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ChatBskyLexicon.Conversation.GetConversationAvailabilityOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/UpdateAllRead.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/UpdateAllRead.swift
@@ -40,7 +40,7 @@ extension ATProtoBlueskyChat {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
@@ -49,7 +49,7 @@ extension ATProtoBlueskyChat {
                 isRelatedToBskyChat: true
             )
 
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ChatBskyLexicon.Conversation.UpdateAllReadOutput.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ActivateAccount.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ActivateAccount.swift
@@ -35,7 +35,7 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -43,7 +43,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(request)
+            _ = try await apiClientService.sendRequest(request)
         } catch {
             throw error
         }

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/AddReservedHandle.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/AddReservedHandle.swift
@@ -43,7 +43,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -51,7 +51,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ApplyWrites.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ApplyWrites.swift
@@ -52,7 +52,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -60,7 +60,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CheckAccountStatus.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CheckAccountStatus.swift
@@ -40,13 +40,13 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Server.CheckAccountStatusOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CheckSignupQueue.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CheckSignupQueue.swift
@@ -39,19 +39,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Temp.CheckSignupQueueOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoSyncGetHostStatusMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoSyncGetHostStatusMethod.swift
@@ -44,19 +44,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Sync.GetHostStatusOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoSyncListHostsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoSyncListHostsMethod.swift
@@ -56,19 +56,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Sync.ListHostsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ConfirmEmail.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ConfirmEmail.swift
@@ -53,7 +53,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -61,7 +61,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateAccount.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateAccount.swift
@@ -76,14 +76,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Server.CreateAccountOutput.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateAppPassword.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateAppPassword.swift
@@ -51,14 +51,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Server.CreateAppPasswordOutput.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateInviteCode.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateInviteCode.swift
@@ -51,14 +51,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Server.CreateInviteCodeOutput.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateInviteCodes.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateInviteCodes.swift
@@ -47,14 +47,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Server.CreateInviteCodesOutput.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateRecord.swift
@@ -65,14 +65,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Repository.StrongReference.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateReport.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateReport.swift
@@ -51,14 +51,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Moderation.CreateReportOutput.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateSession.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/CreateSession.swift
@@ -53,12 +53,12 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post
             )
 
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Server.CreateSessionOutput.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DeactivateAccount.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DeactivateAccount.swift
@@ -45,7 +45,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -53,7 +53,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DeleteAccount.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DeleteAccount.swift
@@ -51,7 +51,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -59,7 +59,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DeleteRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DeleteRecord.swift
@@ -57,7 +57,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -65,7 +65,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DeleteSession.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DeleteSession.swift
@@ -38,11 +38,11 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(forRequest: requestURL,
+            let request = apiClientService.createRequest(forRequest: requestURL,
                                                          andMethod: .post,
                                                          authorizationValue: "Bearer \(refreshToken)")
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request
             )
         } catch {

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DescribeRepository.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DescribeRepository.swift
@@ -40,19 +40,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Repository.DescribeRepositoryOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DescribeServer.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/DescribeServer.swift
@@ -29,14 +29,14 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Server.DescribeServerOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetAccountInviteCodes.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetAccountInviteCodes.swift
@@ -51,19 +51,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Server.GetAccountInviteCodesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetBlob.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetBlob.swift
@@ -42,19 +42,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "'*/*'",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(request)
+            let response = try await apiClientService.sendRequest(request)
 
             return response
         } catch {

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetLatestCommit.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetLatestCommit.swift
@@ -37,19 +37,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/vnd.ipld.car",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Sync.GetLatestCommitOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetRecommendedDidCredentials.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetRecommendedDidCredentials.swift
@@ -29,14 +29,14 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request, decodeTo:
                 ComAtprotoLexicon.Identity.GetRecommendedDidCredentialsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetRepoRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetRepoRecord.swift
@@ -50,17 +50,17 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Repository.GetRecordOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetRepository.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetRepository.swift
@@ -45,19 +45,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/vnd.ipld.car",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(request)
+            let response = try await apiClientService.sendRequest(request)
 
             return response
         } catch {

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetRepositoryStatus.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetRepositoryStatus.swift
@@ -44,19 +44,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Sync.GetRepositoryStatusOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetServiceAuthentication.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetServiceAuthentication.swift
@@ -60,19 +60,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Server.GetServiceAuthOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetSession.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetSession.swift
@@ -36,12 +36,12 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Server.GetSessionOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetSyncBlocks.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetSyncBlocks.swift
@@ -46,19 +46,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/vnd.ipld.car",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(request)
+            let response = try await apiClientService.sendRequest(request)
 
             return response
         } catch {

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetSyncRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/GetSyncRecord.swift
@@ -50,19 +50,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/vnd.ipld.car",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(request)
+            let response = try await apiClientService.sendRequest(request)
 
             return response
         } catch {

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ImportRepository.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ImportRepository.swift
@@ -40,7 +40,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: nil,
@@ -48,7 +48,7 @@ extension ATProtoKit {
                 authorizationValue: nil
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListAppPasswords.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListAppPasswords.swift
@@ -38,14 +38,14 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Server.ListAppPasswordsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListBlobs.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListBlobs.swift
@@ -59,19 +59,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/vnd.ipld.car",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Sync.ListBlobsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListMissingBlobs.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListMissingBlobs.swift
@@ -56,19 +56,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Repository.ListMissingBlobsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListRecords.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListRecords.swift
@@ -62,19 +62,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Repository.ListRecordsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListRepositories.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListRepositories.swift
@@ -50,19 +50,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Sync.ListRepositoriesOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListRepositoriesByCollection.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ListRepositoriesByCollection.swift
@@ -54,19 +54,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Sync.ListRepositoriesByCollectionOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/NotifyOfUpdate.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/NotifyOfUpdate.swift
@@ -43,7 +43,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -51,7 +51,7 @@ extension ATProtoKit {
                 authorizationValue: nil
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/PutRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/PutRecord.swift
@@ -65,14 +65,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Repository.StrongReference.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/QueryLabels.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/QueryLabels.swift
@@ -70,19 +70,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: authorizationValue
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Label.QueryLabelsOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RefreshIdentity.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RefreshIdentity.swift
@@ -36,7 +36,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -44,7 +44,7 @@ extension ATProtoKit {
                 authorizationValue: nil
             )
 
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Identity.IdentityInfoDefinition.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RefreshSession.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RefreshSession.swift
@@ -35,10 +35,10 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(forRequest: requestURL,
+            let request = apiClientService.createRequest(forRequest: requestURL,
                                                          andMethod: .post,
                                                          authorizationValue: "Bearer \(refreshToken)")
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Server.RefreshSessionOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestAccountDelete.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestAccountDelete.swift
@@ -37,7 +37,7 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -45,7 +45,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(request)
+            _ = try await apiClientService.sendRequest(request)
         } catch {
             throw error
         }

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestCrawl.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestCrawl.swift
@@ -40,7 +40,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -48,7 +48,7 @@ extension ATProtoKit {
                 authorizationValue: nil
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestEmailConfirmation.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestEmailConfirmation.swift
@@ -34,7 +34,7 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -42,7 +42,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(request)
+            _ = try await apiClientService.sendRequest(request)
         } catch {
             throw error
         }

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestEmailUpdate.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestEmailUpdate.swift
@@ -36,14 +36,14 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Server.RequestEmailUpdateOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestPLCOperationSignature.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestPLCOperationSignature.swift
@@ -34,7 +34,7 @@ extension ATProtoKit {
         }
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -42,7 +42,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(request)
+            _ = try await apiClientService.sendRequest(request)
         } catch {
             throw error
         }

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestPasswordReset.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestPasswordReset.swift
@@ -34,7 +34,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -42,7 +42,7 @@ extension ATProtoKit {
                 authorizationValue: nil
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestPhoneVerification.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RequestPhoneVerification.swift
@@ -46,7 +46,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
@@ -54,7 +54,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ReserveSigningKey.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ReserveSigningKey.swift
@@ -35,14 +35,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Server.ReserveSigningKeyOutput.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ResetPassword.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ResetPassword.swift
@@ -40,7 +40,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -48,7 +48,7 @@ extension ATProtoKit {
                 authorizationValue: nil
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ResolveDID.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ResolveDID.swift
@@ -35,19 +35,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Identity.ResolveDIDOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ResolveHandle.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ResolveHandle.swift
@@ -36,19 +36,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Identity.ResolveHandleOutput.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ResolveIdentity.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ResolveIdentity.swift
@@ -36,19 +36,19 @@ extension ATProtoKit {
         let queryURL: URL
 
         do {
-            queryURL = try APIClientService.setQueryItems(
+            queryURL = try apiClientService.setQueryItems(
                 for: requestURL,
                 with: queryItems
             )
 
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: queryURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 decodeTo: ComAtprotoLexicon.Identity.IdentityInfoDefinition.self
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RevokeAppPassword.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/RevokeAppPassword.swift
@@ -40,7 +40,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -48,7 +48,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/SignPLCOperation.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/SignPLCOperation.swift
@@ -59,14 +59,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
-            let response = try await APIClientService.shared.sendRequest(
+            let response = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody,
                 decodeTo: ComAtprotoLexicon.Identity.SignPLCOperationOutput.self

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/SubmitPLCOperation.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/SubmitPLCOperation.swift
@@ -33,14 +33,14 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: nil
             )
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/UpdateEmail.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/UpdateEmail.swift
@@ -53,7 +53,7 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
@@ -61,7 +61,7 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/UpdateHandle.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/UpdateHandle.swift
@@ -41,13 +41,13 @@ extension ATProtoKit {
         )
 
         do {
-            let request = await APIClientService.createRequest(
+            let request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 authorizationValue: "Bearer \(accessToken)"
             )
 
-            _ = try await APIClientService.shared.sendRequest(
+            _ = try await apiClientService.sendRequest(
                 request,
                 withEncodingBody: requestBody
             )

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/UploadBlob.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/UploadBlob.swift
@@ -42,14 +42,14 @@ extension ATProtoKit {
         let mimeType = APIClientService.mimeType(for: filename)
 
         do {
-            var request = await APIClientService.createRequest(
+            var request = apiClientService.createRequest(
                 forRequest: requestURL,
                 andMethod: .post,
                 contentTypeValue: mimeType,
                 authorizationValue: "Bearer \(accessToken)")
             request.httpBody = imageData
 
-            let response = try await APIClientService.shared.sendRequest(request,
+            let response = try await apiClientService.sendRequest(request,
                                                       decodeTo: ComAtprotoLexicon.Repository.BlobContainer.self)
 
             return response

--- a/Sources/ATProtoKit/APIReference/SessionManager/SessionConfiguration.swift
+++ b/Sources/ATProtoKit/APIReference/SessionManager/SessionConfiguration.swift
@@ -241,7 +241,7 @@ extension SessionConfiguration {
         // Loop until an error has been thrown, or until the response has been added.
         while response == nil {
             do {
-                response = try await ATProtoKit(urlSessionConfiguration: configuration, pdsURL: self.pdsURL, canUseBlueskyRecords: false)
+                response = try await ATProtoKit(apiClientConfiguration: .init(urlSessionConfiguration: configuration), pdsURL: self.pdsURL, canUseBlueskyRecords: false)
                     .createSession(
                         with: handle,
                         and: password,
@@ -328,7 +328,7 @@ extension SessionConfiguration {
         }
 
         do {
-            let response = try await ATProtoKit(urlSessionConfiguration: configuration, pdsURL: self.pdsURL, canUseBlueskyRecords: false)
+            let response = try await ATProtoKit(apiClientConfiguration: .init(urlSessionConfiguration: configuration), pdsURL: self.pdsURL, canUseBlueskyRecords: false)
                 .getSession(
                 by: accessToken
             )
@@ -409,7 +409,7 @@ extension SessionConfiguration {
         }
 
         do {
-            let response = try await ATProtoKit(urlSessionConfiguration: configuration, pdsURL: self.pdsURL, canUseBlueskyRecords: false)
+            let response = try await ATProtoKit(apiClientConfiguration: .init(urlSessionConfiguration: configuration), pdsURL: self.pdsURL, canUseBlueskyRecords: false)
                 .refreshSession(
                 refreshToken: refreshToken
             )
@@ -483,7 +483,7 @@ extension SessionConfiguration {
         }
 
         do {
-            try await ATProtoKit(urlSessionConfiguration: configuration, pdsURL: self.pdsURL, canUseBlueskyRecords: false)
+            try await ATProtoKit(apiClientConfiguration: .init(urlSessionConfiguration: configuration), pdsURL: self.pdsURL, canUseBlueskyRecords: false)
                 .deleteSession(
                 refreshToken: refreshToken
             )

--- a/Sources/ATProtoKit/ATProtoKit.swift
+++ b/Sources/ATProtoKit/ATProtoKit.swift
@@ -184,7 +184,6 @@ public final class ATProtoKit: Sendable, ATProtoKitConfiguration, ATRecordConfig
         sessionConfiguration: SessionConfiguration? = nil,
         apiClientConfiguration: APIClientConfiguration? = nil,
         pdsURL: String = "https://public.api.bsky.app",
-        responseProvider: ATRequestExecutor? = nil,
         canUseBlueskyRecords: Bool = true
     ) {
         self.sessionConfiguration = sessionConfiguration
@@ -231,7 +230,6 @@ public final class ATProtoKit: Sendable, ATProtoKitConfiguration, ATRecordConfig
         sessionConfiguration: SessionConfiguration? = nil,
         apiClientConfiguration: APIClientConfiguration? = nil,
         pdsURL: String = "https://public.api.bsky.app",
-        responseProvider: ATRequestExecutor? = nil,
         canUseBlueskyRecords: Bool = true
     ) async {
         self.sessionConfiguration = sessionConfiguration
@@ -300,6 +298,11 @@ public final class ATProtoBlueskyChat: Sendable, ATProtoKitConfiguration {
 
     /// Represents the instance of ``ATProtoKit/ATProtoKit``.
     internal let atProtoKitInstance: ATProtoKit
+    
+    /// The instance of ``APIClientService`` in  ``atProtoKitInstance``
+    internal var apiClientService: APIClientService {
+        atProtoKitInstance.apiClientService
+    }
 
     /// Initializes a new instance of `ATProtoBlueskyChat`.
     ///

--- a/Sources/ATProtoKit/Utilities/APIClientConfiguration.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientConfiguration.swift
@@ -1,0 +1,45 @@
+//
+//  APIClientConfiguration.swift
+//  ATProtoKit
+//
+//  Created by Michael Freiwald on 30.05.25.
+//
+
+import Foundation
+
+/// A configuration container for customizing the behavior of an API client.
+///
+/// `APIClientConfiguration` enables fine-grained control over the underlying networking stack used by an API client, including session configuration, delegate handling, response execution, and logging.
+///
+/// You can use this type to inject custom dependencies or modify default behaviors. All properties are optional, and reasonable defaults are provided where possible.
+///
+/// - Parameters:
+///   - urlSessionConfiguration: The configuration object that defines behavior and policies for a URL session. If `nil`, uses `URLSessionConfiguration.default`.
+///   - delegate: The delegate object that handles session-level events, such as authentication challenges or background events. If `nil`, no delegate is used.
+///   - delegateQueue: The operation queue on which the delegate callbacks are dispatched. If `nil`, the system provides a default delegate queue.
+///   - responseProvider: An object responsible for executing requests and providing responses. Useful for dependency injection and testing. If `nil`, the default executor is used.
+///   - logger: An object conforming to `SessionDebuggable` for capturing debug information and logging session activity. If `nil`, logging is disabled.
+///
+/// - SeeAlso: [URLSessionConfiguration](https://developer.apple.com/documentation/foundation/urlsessionconfiguration), [URLSessionDelegate](https://developer.apple.com/documentation/foundation/urlsessiondelegate)
+public struct APIClientConfiguration: Sendable {
+    var urlSessionConfiguration: URLSessionConfiguration? = .default
+    var delegate: (any URLSessionDelegate)? = nil
+    var delegateQueue: OperationQueue? = nil
+    var responseProvider: ATRequestExecutor? = nil
+    var logger: SessionDebuggable? = nil
+
+    /// Creates a new API client configuration with optional customization points.
+    public init(
+        urlSessionConfiguration: URLSessionConfiguration? = nil,
+        delegate: (any URLSessionDelegate)? = nil,
+        delegateQueue: OperationQueue? = nil,
+        responseProvider: ATRequestExecutor? = nil,
+        logger: SessionDebuggable? = nil
+    ) {
+        self.urlSessionConfiguration = urlSessionConfiguration
+        self.delegate = delegate
+        self.delegateQueue = delegateQueue
+        self.responseProvider = responseProvider
+        self.logger = logger
+    }
+}

--- a/Sources/ATProtoKit/Utilities/APIClientConfiguration.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientConfiguration.swift
@@ -27,7 +27,7 @@ import Foundation
 ///
 /// - SeeAlso: [URLSessionConfiguration](https://developer.apple.com/documentation/foundation/urlsessionconfiguration), [URLSessionDelegate](https://developer.apple.com/documentation/foundation/urlsessiondelegate)
 public struct APIClientConfiguration: Sendable {
-    var urlSessionConfiguration: URLSessionConfiguration? = .default
+    var urlSessionConfiguration: URLSessionConfiguration?
     var delegate: (any URLSessionDelegate)? = nil
     var delegateQueue: OperationQueue? = nil
     var responseProvider: ATRequestExecutor? = nil

--- a/Sources/ATProtoKit/Utilities/APIClientConfiguration.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientConfiguration.swift
@@ -14,11 +14,16 @@ import Foundation
 /// You can use this type to inject custom dependencies or modify default behaviors. All properties are optional, and reasonable defaults are provided where possible.
 ///
 /// - Parameters:
-///   - urlSessionConfiguration: The configuration object that defines behavior and policies for a URL session. If `nil`, uses `URLSessionConfiguration.default`.
-///   - delegate: The delegate object that handles session-level events, such as authentication challenges or background events. If `nil`, no delegate is used.
-///   - delegateQueue: The operation queue on which the delegate callbacks are dispatched. If `nil`, the system provides a default delegate queue.
-///   - responseProvider: An object responsible for executing requests and providing responses. Useful for dependency injection and testing. If `nil`, the default executor is used.
-///   - logger: An object conforming to `SessionDebuggable` for capturing debug information and logging session activity. If `nil`, logging is disabled.
+///   - configuration: An instance of `URLSessionConfiguration`. Optional.
+///   Defaults to `.default`.
+///   - delegate: A session delegate object that handles requests for authentication and other
+///   session-related events.
+///   - delegateQueue: An operation queue for scheduling the delegate calls and
+///   completion handlers.
+///   - responseProvider: A provider used for the response of the `URLRequest`. Optional.
+///   Defaults to `nil`.
+///   - logger: An instance of ``SessionDebuggable`` to attach to `APIClientService`.
+///   Optional. Defaults to `nil`.    
 ///
 /// - SeeAlso: [URLSessionConfiguration](https://developer.apple.com/documentation/foundation/urlsessionconfiguration), [URLSessionDelegate](https://developer.apple.com/documentation/foundation/urlsessiondelegate)
 public struct APIClientConfiguration: Sendable {

--- a/Sources/ATProtoKit/Utilities/APIClientService.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientService.swift
@@ -117,7 +117,7 @@ public struct APIClientService: Sendable {
     /// - Returns: A configured `URLRequest` instance.
     public func createRequest(forRequest requestURL: URL, andMethod httpMethod: HTTPMethod, acceptValue: String? = "application/json",
                                      contentTypeValue: String? = "application/json", authorizationValue: String? = nil,
-                                     labelersValue: String? = nil, proxyValue: String? = nil, isRelatedToBskyChat: Bool = false) async -> URLRequest {
+                                     labelersValue: String? = nil, proxyValue: String? = nil, isRelatedToBskyChat: Bool = false) -> URLRequest {
         var request = URLRequest(url: requestURL)
         request.httpMethod = httpMethod.rawValue
 

--- a/Sources/ATProtoKit/Utilities/APIClientService.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientService.swift
@@ -289,8 +289,10 @@ public actor APIClientService {
                 (data, response) = try await urlSession.data(for: urlRequest)
             }
 
+            #if DEBUG
             self.logger?.logResponse(response, data: data, error: nil)
-
+            #endif
+            
             if let httpResponse = response as? HTTPURLResponse {
                 switch httpResponse.statusCode {
                     case 200:

--- a/Sources/ATProtoKit/Utilities/APIClientService.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientService.swift
@@ -10,12 +10,11 @@ import Foundation
 @_exported import FoundationNetworking
 #endif
 
-/// An actor which handle the most common HTTP requests for the AT Protocol.
+/// A struct which handle the most common HTTP requests for the AT Protocol.
 ///
 /// This is, effectively, the meat of the "XRPC" portion of the AT Protocol, which creates
-/// the communitcation between the client and the server. Only one instance of this actor can be
-/// active at once.
-public actor APIClientService {
+/// the communitcation between the client and the server.
+public struct APIClientService: Sendable {
 
     /// The `URLSession` instance to be used for network requests.
     public private(set) var urlSession: URLSession = URLSession(configuration: .default)
@@ -81,41 +80,25 @@ public actor APIClientService {
         return userAgent
     }()
 
-    /// A `URLSession` object for use in all HTTP requests.
-    public static let shared = APIClientService()
-
-    /// Creates an instance for use in accepting and returning API requests and
-    /// responses respectively.
-    private init() {}
-
-    /// Configures the singleton instance with a custom `URLSessionConfiguration`.
+    /// Initializes an API client service using the specified configuration.
     ///
-    /// - Note: Both `delegate` and `delegateQueue` are related to `URLSession`.
+    /// Use this initializer to create an API client that accepts and returns API requests and responses,
+    /// with support for custom session configuration, delegate handling, response providers, and logging.
     ///
     /// - Parameters:
-    ///   - configuration: An instance of `URLSessionConfiguration`. Optional.
-    ///   Defaults to `.default`.
-    ///   - delegate: A session delegate object that handles requests for authentication and other
-    ///   session-related events.
-    ///   - delegateQueue: An operation queue for scheduling the delegate calls and
-    ///   completion handlers.
-    ///   - responseProvider: A provider used for the response of the `URLRequest`. Optional.
-    ///   Defaults to `nil`.
-    public func configure(with configuration: URLSessionConfiguration? = .default, delegate: (any URLSessionDelegate)? = nil,
-                          delegateQueue: OperationQueue? = nil, responseProvider: ATRequestExecutor? = nil) async {
-        self.executor = responseProvider
-
-        let config = configuration ?? .default
-        config.httpAdditionalHeaders = ["User-Agent": APIClientService.userAgent]
-        self.urlSession = URLSession(configuration: config, delegate: delegate, delegateQueue: delegateQueue)
-    }
-
-    /// Injects a logger into `APIClientService`.
+    ///   - configuration: The ``APIClientConfiguration`` instance containing all customization options.
+    ///     This includes the session configuration, delegate, delegate queue, response provider, and logger.
+    ///     If `urlSessionConfiguration` is `nil`, `.default` is used. If `responseProvider` or `logger` are
+    ///     `nil`, the defaults are used.
     ///
-    /// - Parameter logger: An instance of ``SessionDebuggable`` to attach to `APIClientService`.
-    /// Optional. Defaults to `nil`.
-    public func setLogger(_ logger: SessionDebuggable? = nil) {
-        self.logger = logger
+    /// - SeeAlso:
+    ///   - ``APIClientConfiguration``
+    public init(with configuration: APIClientConfiguration) {
+        let config = configuration.urlSessionConfiguration ?? .default
+        config.httpAdditionalHeaders = ["User-Agent": APIClientService.userAgent]
+        self.urlSession = URLSession(configuration: config, delegate: configuration.delegate, delegateQueue: configuration.delegateQueue)
+        self.executor = configuration.responseProvider
+        self.logger = configuration.logger
     }
 
 // MARK: Creating requests -
@@ -132,7 +115,7 @@ public actor APIClientService {
     ///   - isRelatedToBskyChat: Indicates whether to use the "atproto-proxy" header for
     ///   the value specific to Bluesky DMs. Optional. Defaults to `false`.
     /// - Returns: A configured `URLRequest` instance.
-    public static func createRequest(forRequest requestURL: URL, andMethod httpMethod: HTTPMethod, acceptValue: String? = "application/json",
+    public func createRequest(forRequest requestURL: URL, andMethod httpMethod: HTTPMethod, acceptValue: String? = "application/json",
                                      contentTypeValue: String? = "application/json", authorizationValue: String? = nil,
                                      labelersValue: String? = nil, proxyValue: String? = nil, isRelatedToBskyChat: Bool = false) async -> URLRequest {
         var request = URLRequest(url: requestURL)
@@ -142,7 +125,7 @@ public actor APIClientService {
             request.addValue(acceptValue, forHTTPHeaderField: "Accept")
         }
 
-        if let authorizationValue, await APIClientService.shared.executor == nil {
+        if let authorizationValue, executor == nil {
             request.addValue(authorizationValue, forHTTPHeaderField: "Authorization")
         }
 
@@ -182,7 +165,7 @@ public actor APIClientService {
     ///   - requestURL: The base URL to append query items to.
     ///   - queryItems: An array of key-value pairs to be set as query items.
     /// - Returns: A new URL with the query items appended.
-    public static func setQueryItems(for requestURL: URL, with queryItems: [(String, String)]) throws -> URL {
+    public func setQueryItems(for requestURL: URL, with queryItems: [(String, String)]) throws -> URL {
         var components = URLComponents(url: requestURL, resolvingAgainstBaseURL: true)
 
         // Map out each URLQueryItem with the key ($0.0) and value ($0.1) of the item.


### PR DESCRIPTION
## Description
Using `APIClientService.shared` causes issues with the `.configuration` call.
Instanziating more `ATProtoKit` instances are overwriting the `APIClientService` properties like `ATRequestExecutor`.

That's why this PR is removing the singleton instance and each ATProtoKit object contains its own instance of APIClientService.

I recommend going through the single commits for review because of all the file changes.

## Linked Discussion
https://github.com/MasterJ93/ATProtoKit/discussions/167

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

