### PR TITLE
Remove UserSessionRegistry update function

### DIFF
--- a/Sources/ATProtoKit/APIReference/SessionManager/SessionConfiguration.swift
+++ b/Sources/ATProtoKit/APIReference/SessionManager/SessionConfiguration.swift
@@ -368,7 +368,7 @@ extension SessionConfiguration {
                 pdsURL: self.pdsURL
             )
 
-            _ = await UserSessionRegistry.shared.update(instanceUUID, with: updatedUserSession)
+          _ = await UserSessionRegistry.shared.register(instanceUUID, session: updatedUserSession)
         } catch {
             throw error
         }
@@ -451,7 +451,7 @@ extension SessionConfiguration {
                 pdsURL: self.pdsURL
             )
 
-            _ = await UserSessionRegistry.shared.update(instanceUUID, with: updatedUserSession)
+          _ = await UserSessionRegistry.shared.register(instanceUUID, session: updatedUserSession)
         } catch {
             throw error
         }

--- a/Sources/ATProtoKit/APIReference/SessionManager/UserSessionRegistry.swift
+++ b/Sources/ATProtoKit/APIReference/SessionManager/UserSessionRegistry.swift
@@ -48,21 +48,6 @@ public actor UserSessionRegistry {
         return sessions.keys.contains(id)
     }
 
-    /// Updates an existing instance of `UserSession` with a new instance.
-    ///
-    /// - Parameters:
-    ///   - id: The UUID of the existing session to update.
-    ///   - newSession: The updated `UserSession` instance.
-    /// - Returns: `true` if the update succeeded, `false` if the session didn’t exist.
-    public func update(_ id: UUID, with newSession: UserSession) -> Bool {
-        guard sessions.keys.contains(id) else {
-            return false
-        }
-
-        sessions[id] = newSession
-        return true
-    }
-
     /// Removes a specific user session by UUID.
     ///
     /// - Parameter id: The UUID of the session to remove.


### PR DESCRIPTION
This allows the `refreshSession` to correctly set the session in the `UserSessionRegistry` when we only need to `refreshSession` and not `authenticate`. Like when an already logged in user launches the app from a killed state
