### PR TITLE
Fixed defect where a non-public initializer prevented creating an instance of  RecordKeyManager

### DIFF
--- a/Sources/ATProtoKit/Utilities/ATProtoIdentifiers/RecordKeyManager.swift
+++ b/Sources/ATProtoKit/Utilities/ATProtoIdentifiers/RecordKeyManager.swift
@@ -22,7 +22,7 @@ public struct RecordKeyManager {
     /// A list of the valid characters in base32.
     private let base32Alphabet = "234567abcdefghijklmnopqrstuvwxyz"
 
-    init() {
+    public init() {
         // Generate a random 10-bit clock identifier.
         clockIdentifier = UInt64.random(in: 0..<1023)
     }


### PR DESCRIPTION
## Description
RecordKeyManager could not be instantiated due to non-public initializer.

## Linked Issues
Link any related issues here. Format: `#[issue number]`

## Type of Change
- [X] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [X] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [X] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings or errors in the compiler or runtime.
- [X] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Consider making RecordKeyManager a static struct/class/method instead of persistent. Also, this functionality seems more applicable to being in the MultiformatsKit. 

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
