### PR TITLE
Fix: Add public initializers for SavedFeed and SavedFeedPreferencesVe…

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
@@ -948,6 +948,20 @@ extension AppBskyLexicon.Actor {
         /// Indicated whether the saved feed generator is pinned.
         public let isPinned: Bool
 
+        /// Creates a new saved feed instance.
+        ///
+        /// - Parameters:
+        ///   - feedID: The ID for the saved feed.
+        ///   - feedType: The type of feed generator.
+        ///   - value: The value of the saved feed generator.
+        ///   - isPinned: Indicates whether the saved feed generator is pinned.
+        public init(feedID: String, feedType: FeedType, value: String, isPinned: Bool) {
+            self.feedID = feedID
+            self.feedType = feedType
+            self.value = value
+            self.isPinned = isPinned
+        }
+
         /// The type of feed generator.
         ///
         /// This is usually referring to the location of the feed in context to the
@@ -988,6 +1002,13 @@ extension AppBskyLexicon.Actor {
 
         /// An array of saved feed generators.
         public let items: [SavedFeed]
+
+        /// Creates a new saved feed preferences version 2 instance.
+        ///
+        /// - Parameter items: An array of saved feed generators.
+        public init(items: [SavedFeed]) {
+            self.items = items
+        }
 
         enum CodingKeys: String, CodingKey {
             case type = "$type"


### PR DESCRIPTION
## Problem

When working with saved feeds preferences, it's currently impossible to create instances of `SavedFeed` and `SavedFeedPreferencesVersion2Definition` without using JSON serialization workarounds. These structs only have `Decodable` initializers, which makes programmatic creation unnecessarily complex.

## Solution

This PR adds public initializers for:
- `AppBskyLexicon.Actor.SavedFeed`
- `AppBskyLexicon.Actor.SavedFeedPreferencesVersion2Definition`

## Changes

Added public initializers following ATProtoKit's strict guidelines:
- Proper documentation with triple slashes
- All parameters documented
- Follows the established code structure pattern

## Testing

The initializers have been tested to ensure they create objects identical to those decoded from JSON responses.

## Example Usage

```swift
// Before (workaround required)
let savedFeedDict: [String: Any] = [
    "id": UUID().uuidString,
    "type": "list",
    "pinned": true,
    "$type": "app.bsky.actor.defs#savedFeed",
    "value": listURI
]
let jsonData = try JSONSerialization.data(withJSONObject: savedFeedDict)
let savedFeed = try JSONDecoder().decode(SavedFeed.self, from: jsonData)

// After (with this PR)
let savedFeed = SavedFeed(
    feedID: UUID().uuidString,
    feedType: .list,
    value: listURI,
    isPinned: true
)