### PR TITLE
Fix: Explicitly set Content-Type to application/json in putPreferences

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyActorPreferencesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyActorPreferencesMethod.swift
@@ -47,7 +47,7 @@ extension ATProtoKit {
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
-                contentTypeValue: nil,
+                contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
 


### PR DESCRIPTION
## Description

### Problem

The `putPreferences` method in `AppBskyActorPreferencesMethod.swift` does not explicitly set the `Content-Type` header. As a result, the request defaults to `application/x-www-form-urlencoded`, which causes the Bluesky API to reject the request with:

```
Wrong request encoding (Content-Type): application/x-www-form-urlencoded
```

### Solution

Set the `contentTypeValue` parameter to `"application/json"` in the request creation. This aligns with the API's expectation for JSON-encoded payloads.

### Changes

```swift
let request = apiClientService.createRequest(
    forRequest: requestURL,
    andMethod: .post,
    acceptValue: nil,
    contentTypeValue: "application/json",
    authorizationValue: "Bearer \(accessToken)"
)
```

### Impact

This change ensures that the `putPreferences` method works correctly and adheres to the ATProto specification for the `app.bsky.actor.putPreferences` endpoint.

No other functionality is affected.