### PR TITLE
Fix: ATFacetParser fails to detect mentions/URLs at start of text

### DIFF
--- a/Sources/ATProtoKit/Utilities/ATFacetParser.swift
+++ b/Sources/ATProtoKit/Utilities/ATFacetParser.swift
@@ -22,7 +22,7 @@ public class ATFacetParser {
         var spans = [[String: Any]]()
 
         // Regex for grabbing @mentions based on Bluesky's regex.
-        let mentionRegex = "[\\s|^](@([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)"
+        let mentionRegex = "(?:(?<=\\s)|(?<=^))(@([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)"
 
         do {
             let regex = try NSRegularExpression(pattern: mentionRegex)
@@ -65,7 +65,7 @@ public class ATFacetParser {
         var spans = [[String: Any]]()
 
         // Regular expression pattern for identifying URLs.
-        let linkRegex = "[\\s|^](https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*[-a-zA-Z0-9@%_\\+~#//=])?)"
+        let linkRegex = "(?:(?<=\\s)|(?<=^))(https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&//=]*[-a-zA-Z0-9@%_\\+~#//=])?)"
 
         do {
             let regex = try NSRegularExpression(pattern: linkRegex)

--- a/Tests/ATProtoKitTests/ATFacetParserTests.swift
+++ b/Tests/ATProtoKitTests/ATFacetParserTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import ATProtoKit
+
+final class ATFacetParserTests: XCTestCase {
+    func testURLAtStartIsDetected() {
+        let text = "https://example.com is my site"
+        let result = ATFacetParser.parseURLs(from: text)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?["link"] as? String, "https://example.com")
+        XCTAssertEqual(result.first?["start"] as? Int, 0)
+    }
+
+    func testURLAfterSpaceIsDetected() {
+        let text = " visit https://example.com now"
+        let result = ATFacetParser.parseURLs(from: text)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?["link"] as? String, "https://example.com")
+    }
+
+    func testMentionAtStartIsDetected() {
+        let text = "@user.bsky.social says hi"
+        let result = ATFacetParser.parseMentions(from: text)
+
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?["mention"] as? String, "@user.bsky.social")
+        XCTAssertEqual(result.first?["start"] as? Int, 0)
+    }
+
+}


### PR DESCRIPTION
## Description
Fixes a bug in `ATFacetParser.swift` where mentions and URLs were not detected when they appeared at the very start of a string.

## Linked Issues
#199 

## Type of Change
- [x] Bug Fix

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.


## Additional Notes
### Affected methods
- `ATFacetParser.parseMentions(from:)`
- `ATFacetParser.parseURLs(from:)`

### Fix
- Replaced `[\\s|^]` with a proper lookbehind regex: `(?:(?<=\\s)|(?<=^))`
- Ensures detection at position 0 (start of text), not just after a space

### Tests
Added unit tests in `ATFacetParserTests.swift`:
- Detect URL at start of string
- Detect URL after space
- Detect mention at start of string