### PR TITLE
Fix PreferenceUnion encoding to preserve $type field in putPreferences

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
@@ -798,37 +798,51 @@ extension AppBskyLexicon.Actor {
 
         // Implement custom encoding
         public func encode(to encoder: Encoder) throws {
-            var container = encoder.singleValueContainer()
+            var container = encoder.container(keyedBy: CodingKeys.self)
 
             switch self {
                 case .adultContent(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#adultContentPref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .contentLabel(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#contentLabelPref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .savedFeedsVersion2(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#savedFeedsPrefV2", forKey: .type)
+                    try value.encode(to: encoder)
                 case .savedFeeds(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#savedFeedsPref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .personalDetails(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#personalDetailsPref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .feedView(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#feedViewPref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .threadView(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#threadViewPref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .interestViewPreferences(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#interestsPref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .mutedWordsPreferences(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#mutedWordsPref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .hiddenPostsPreferences(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#hiddenPostsPref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .bskyAppStatePreferences(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#bskyAppStatePref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .labelersPreferences(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#labelersPref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .postInteractionSettingsPreference(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#postInteractionSettingsPref", forKey: .type)
+                    try value.encode(to: encoder)
                 case .verificationPreference(let value):
-                    try container.encode(value)
+                    try container.encode("app.bsky.actor.defs#verificationPrefs", forKey: .type)
+                    try value.encode(to: encoder)
                 default:
                     break
             }


### PR DESCRIPTION
## Problem
The `putPreferences` method was failing with the following error:
`badRequest(error: ATProtoKit.APIClientService.ATHTTPResponseError(error: "InvalidRequest", message: "Input/preferences/0 must be an object which includes the $type property"))`

## Root Cause
The `PreferenceUnion.encode(to:)` method was using `singleValueContainer` which caused the loss of the required `$type` field when serializing preferences. According to AT Protocol specifications, union variants must always include the `$type` field.

## Solution
Changed the encoding implementation from `singleValueContainer` to `container(keyedBy:)` and explicitly encode the `$type` field for each preference type:

```swift
// Before
var container = encoder.singleValueContainer()
try container.encode(value)

// After
var container = encoder.container(keyedBy: CodingKeys.self)
try container.encode("app.bsky.actor.defs#adultContentPref", forKey: .type)
try value.encode(to: encoder)
```
## Testing
- Built the project successfully
- Verified that all preference types now correctly include the $type field in their JSON output
- The fix ensures AT Protocol compliance for union type encoding

## Impact
This fix resolves the critical issue preventing users from updating their preferences through the putPreferences API method.

The PreferenceUnion encode method was using singleValueContainer which caused the loss of the required $type field when serializing preferences. This resulted in API errors when calling putPreferences:

`"Input/preferences/0 must be an object which includes the \"$type\" property"`

Changed the implementation to use container(keyedBy:) and explicitly encode the $type field for each preference type, ensuring AT Protocol compliance for union variants.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.
