### PR TITLE
Fix: Add missing $type field to admin/moderator union types

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedPost.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedPost.swift
@@ -217,19 +217,24 @@ extension AppBskyLexicon.Feed {
             }
 
             public func encode(to encoder: Encoder) throws {
-                var container = encoder.singleValueContainer()
+                var container = encoder.container(keyedBy: CodingKeys.self)
 
                 switch self {
                     case .images(let imagesValue):
-                        try container.encode(imagesValue)
+                        try container.encode("app.bsky.embed.images", forKey: .type)
+                        try imagesValue.encode(to: encoder)
                     case .video(let value):
-                        try container.encode(value)
+                        try container.encode("app.bsky.embed.video", forKey: .type)
+                        try value.encode(to: encoder)
                     case .external(let externalValue):
-                        try container.encode(externalValue)
+                        try container.encode("app.bsky.embed.external", forKey: .type)
+                        try externalValue.encode(to: encoder)
                     case .record(let recordValue):
-                        try container.encode(recordValue)
+                        try container.encode("app.bsky.embed.record", forKey: .type)
+                        try recordValue.encode(to: encoder)
                     case .recordWithMedia(let recordWithMediaValue):
-                        try container.encode(recordWithMediaValue)
+                        try container.encode("app.bsky.embed.recordWithMedia", forKey: .type)
+                        try recordWithMediaValue.encode(to: encoder)
                     default:
                         break
                 }
@@ -265,11 +270,12 @@ extension AppBskyLexicon.Feed {
             }
 
             public func encode(to encoder: Encoder) throws {
-                var container = encoder.singleValueContainer()
+                var container = encoder.container(keyedBy: CodingKeys.self)
 
                 switch self {
                     case .selfLabels(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.label.defs#selfLabels", forKey: .type)
+                        try value.encode(to: encoder)
                     default:
                         break
                 }

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedPostgate.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedPostgate.swift
@@ -129,11 +129,12 @@ extension AppBskyLexicon.Feed {
             }
 
             public func encode(to encoder: Encoder) throws {
-                var container = encoder.singleValueContainer()
+                var container = encoder.container(keyedBy: CodingKeys.self)
 
                 switch self {
                     case .disabledRule(let disabledRule):
-                        try container.encode(disabledRule)
+                        try container.encode("app.bsky.feed.postgate#disableRule", forKey: .type)
+                        try disabledRule.encode(to: encoder)
                     default:
                         break
                 }

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedThreadgate.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedThreadgate.swift
@@ -186,17 +186,21 @@ extension AppBskyLexicon.Feed {
             }
 
             public func encode(to encoder: Encoder) throws {
-                var container = encoder.singleValueContainer()
+                var container = encoder.container(keyedBy: CodingKeys.self)
 
                 switch self {
                     case .mentionRule(let embedView):
-                        try container.encode(embedView)
+                        try container.encode("app.bsky.feed.threadgate#mentionRule", forKey: .type)
+                        try embedView.encode(to: encoder)
                     case .followerRule(let embedView):
-                        try container.encode(embedView)
+                        try container.encode("app.bsky.feed.threadgate#followerRule", forKey: .type)
+                        try embedView.encode(to: encoder)
                     case .followingRule(let embedView):
-                        try container.encode(embedView)
+                        try container.encode("app.bsky.feed.threadgate#followingRule", forKey: .type)
+                        try embedView.encode(to: encoder)
                     case .listRule(let embedView):
-                        try container.encode(embedView)
+                        try container.encode("app.bsky.feed.threadgate#listRule", forKey: .type)
+                        try embedView.encode(to: encoder)
                     default:
                         break
                 }

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Graph/AppBskyGraphList.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Graph/AppBskyGraphList.swift
@@ -131,11 +131,12 @@ extension AppBskyLexicon.Graph {
             }
 
             public func encode(to encoder: Encoder) throws {
-                var container = encoder.singleValueContainer()
+                var container = encoder.container(keyedBy: CodingKeys.self)
 
                 switch self {
                     case .selfLabels(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.label.defs#selfLabels", forKey: .type)
+                        try value.encode(to: encoder)
                     default:
                         break
                 }

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Admin/ComAtprotoAdminUpdateSubjectStatus.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Admin/ComAtprotoAdminUpdateSubjectStatus.swift
@@ -68,15 +68,18 @@ extension ComAtprotoLexicon.Admin {
             }
 
             public func encode(to encoder: Encoder) throws {
-                var container = encoder.singleValueContainer()
+                var container = encoder.container(keyedBy: CodingKeys.self)
 
                 switch self {
                     case .repositoryReference(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.admin.defs#repoRef", forKey: .type)
+                        try value.encode(to: encoder)
                     case .strongReference(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.repo.strongRef", forKey: .type)
+                        try value.encode(to: encoder)
                     case .repositoryBlobReference(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.admin.defs#repoBlobRef", forKey: .type)
+                        try value.encode(to: encoder)
                     default:
                         break
                 }
@@ -141,15 +144,18 @@ extension ComAtprotoLexicon.Admin {
             }
 
             public func encode(to encoder: Encoder) throws {
-                var container = encoder.singleValueContainer()
+                var container = encoder.container(keyedBy: CodingKeys.self)
 
                 switch self {
                     case .repositoryReference(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.admin.defs#repoRef", forKey: .type)
+                        try value.encode(to: encoder)
                     case .strongReference(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.repo.strongRef", forKey: .type)
+                        try value.encode(to: encoder)
                     case .repositoryBlobReference(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.admin.defs#repoBlobRef", forKey: .type)
+                        try value.encode(to: encoder)
                     default:
                         break
                 }

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Repo/ComAtprotoRepoApplyWrites.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Repo/ComAtprotoRepoApplyWrites.swift
@@ -249,15 +249,18 @@ extension ComAtprotoLexicon.Repository {
             }
 
             public func encode(to encoder: Encoder) throws {
-                var container = encoder.singleValueContainer()
+                var container = encoder.container(keyedBy: CodingKeys.self)
 
                 switch self {
                     case .create(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.repo.applyWrites#create", forKey: .type)
+                        try value.encode(to: encoder)
                     case .update(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.repo.applyWrites#update", forKey: .type)
+                        try value.encode(to: encoder)
                     case .delete(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.repo.applyWrites#delete", forKey: .type)
+                        try value.encode(to: encoder)
                     default:
                         break
                 }
@@ -321,15 +324,18 @@ extension ComAtprotoLexicon.Repository {
             }
 
             public func encode(to encoder: any Encoder) throws {
-                var container = encoder.singleValueContainer()
+                var container = encoder.container(keyedBy: CodingKeys.self)
 
                 switch self {
                     case .createResult(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.repo.applyWrites#createResult", forKey: .type)
+                        try value.encode(to: encoder)
                     case .updateResult(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.repo.applyWrites#updateResult", forKey: .type)
+                        try value.encode(to: encoder)
                     case .deleteResult(let value):
-                        try container.encode(value)
+                        try container.encode("com.atproto.repo.applyWrites#deleteResult", forKey: .type)
+                        try value.encode(to: encoder)
                     default:
                         break
                 }

--- a/Tests/ATProtoKitTests/Models/LabelsUnionTests.swift
+++ b/Tests/ATProtoKitTests/Models/LabelsUnionTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import ATProtoKit
+
+final class LabelsUnionTests: XCTestCase {
+    
+    func testLabelsUnionEncodingIncludesType() throws {
+        // Create a SelfLabelsDefinition
+        let selfLabel = ComAtprotoLexicon.Label.SelfLabelDefinition(value: "adult")
+        let selfLabels = ComAtprotoLexicon.Label.SelfLabelsDefinition(values: [selfLabel])
+        
+        // Create LabelsUnion
+        let labelsUnion = AppBskyLexicon.Graph.ListRecord.LabelsUnion.selfLabels(selfLabels)
+        
+        // Encode to JSON
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .prettyPrinted
+        
+        let data = try encoder.encode(labelsUnion)
+        let jsonString = String(data: data, encoding: .utf8)!
+        
+        print("Encoded LabelsUnion:")
+        print(jsonString)
+        
+        // Verify $type is present
+        XCTAssertTrue(jsonString.contains("\"$type\""), "JSON should contain $type field")
+        XCTAssertTrue(jsonString.contains("\"com.atproto.label.defs#selfLabels\""), "JSON should contain correct $type value")
+        
+        // Parse JSON to verify structure
+        let json = try JSONSerialization.jsonObject(with: data) as! [String: Any]
+        XCTAssertEqual(json["$type"] as? String, "com.atproto.label.defs#selfLabels")
+        XCTAssertNotNil(json["values"], "JSON should contain values array")
+    }
+}


### PR DESCRIPTION
⚠️ This PR depends on #207  and should be merged after it.
This PR only adds changes to `ComAtprotoAdminUpdateSubjectStatus.swift`.

## Description

This PR extends the union type encoding fixes to admin/moderator operations in ATProtoKit. It ensures that union types used in administrative actions properly include the required `$type` field as per AT Protocol specifications.

### Problem
The `SubjectUnion` types in admin update operations were using `singleValueContainer` for encoding, which omitted the required `$type` field. This could cause server rejections when moderators or administrators attempt to update subject statuses.

### Solution
Changed the encoding implementation from `singleValueContainer` to `container(keyedBy:)` and explicitly added the `$type` field for each union case in admin operations.

### Files Changed
- `ComAtprotoAdminUpdateSubjectStatus.swift` - Fixed `SubjectUnion` in both RequestBody and Output structures

### Files Considered but Not Changed
- `ToolsOzoneModerationDefs.swift` - This file contains numerous union types for specialized moderation tools. 

### Testing
- Project builds successfully without warnings
- Encoding changes follow the same pattern as previous union type fixes

### Impact
This fix ensures that admin/moderator operations for updating subject statuses (takedowns, deactivations) will work correctly with AT Protocol servers.

## Linked Issues
#207 
#206 

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.
