### PR TITLE
feat: Automatic Token Refresh - Full Implementation

### DIFF
--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AddMemberAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AddMemberAsAdmin.swift
@@ -40,6 +40,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AddValuesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AddValuesAsAdmin.swift
@@ -29,6 +29,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AdminSearchAccountsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/AdminSearchAccountsAsAdmin.swift
@@ -45,6 +45,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/CreateCommunicationTemplateAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/CreateCommunicationTemplateAsAdmin.swift
@@ -47,6 +47,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteAccountAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteAccountAsAdmin.swift
@@ -34,6 +34,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteCommunicationTemplateAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteCommunicationTemplateAsAdmin.swift
@@ -33,6 +33,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteMemberAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteMemberAsAdmin.swift
@@ -34,6 +34,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteSetAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteSetAsAdmin.swift
@@ -32,6 +32,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteValuesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteValuesAsAdmin.swift
@@ -36,6 +36,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DisableAccountInvitesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DisableAccountInvitesAsAdmin.swift
@@ -39,6 +39,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DisableInviteCodesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DisableInviteCodesAsAdmin.swift
@@ -39,6 +39,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/EmitEventAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/EmitEventAsAdmin.swift
@@ -49,6 +49,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/EnableAccountInvitesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/EnableAccountInvitesAsAdmin.swift
@@ -42,6 +42,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/FindCorrelationAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/FindCorrelationAsAdmin.swift
@@ -32,6 +32,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/FindRelatedAccountsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/FindRelatedAccountsAsAdmin.swift
@@ -43,6 +43,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetAccountInfoAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetAccountInfoAsAdmin.swift
@@ -37,6 +37,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetAccountInfosAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetAccountInfosAsAdmin.swift
@@ -37,6 +37,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetConfigAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetConfigAsAdmin.swift
@@ -31,6 +31,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetInviteCodesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetInviteCodesAsAdmin.swift
@@ -42,6 +42,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetModerationEventAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetModerationEventAsAdmin.swift
@@ -35,6 +35,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRecordAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRecordAsAdmin.swift
@@ -39,6 +39,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetReporterStats.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetReporterStats.swift
@@ -33,6 +33,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRepositoriesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRepositoriesAsAdmin.swift
@@ -31,6 +31,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRepositoryAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetRepositoryAsAdmin.swift
@@ -34,6 +34,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetSubjectStatusAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetSubjectStatusAsAdmin.swift
@@ -42,6 +42,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetSubjectsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetSubjectsAsAdmin.swift
@@ -31,6 +31,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetValuesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/GetValuesAsAdmin.swift
@@ -39,6 +39,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListCommunicationTemplatesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListCommunicationTemplatesAsAdmin.swift
@@ -34,6 +34,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListMembersAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListMembersAsAdmin.swift
@@ -48,6 +48,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListOptionsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ListOptionsAsAdmin.swift
@@ -44,6 +44,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ModerationGetRecordsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ModerationGetRecordsAsAdmin.swift
@@ -31,6 +31,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QueryModerationEventsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QueryModerationEventsAsAdmin.swift
@@ -93,6 +93,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QueryModerationStatusesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QueryModerationStatusesAsAdmin.swift
@@ -129,6 +129,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QuerySetsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/QuerySetsAsAdmin.swift
@@ -44,6 +44,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/RemoveOptionsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/RemoveOptionsAsAdmin.swift
@@ -29,6 +29,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SearchRepositoriesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SearchRepositoriesAsAdmin.swift
@@ -43,6 +43,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SendEmailAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SendEmailAsAdmin.swift
@@ -46,6 +46,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SignatureSearchAccountsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/SignatureSearchAccountsAsAdmin.swift
@@ -41,6 +41,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneHostingGetAccountHistoryMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneHostingGetAccountHistoryMethod.swift
@@ -43,6 +43,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneListVerificationsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneListVerificationsMethod.swift
@@ -53,6 +53,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneSafelinkAddRuleMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneSafelinkAddRuleMethod.swift
@@ -44,6 +44,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneSafelinkQueryEventsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneSafelinkQueryEventsMethod.swift
@@ -40,6 +40,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneSafelinkQueryRulesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneSafelinkQueryRulesMethod.swift
@@ -50,6 +50,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneSafelinkRemoveRuleMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneSafelinkRemoveRuleMethod.swift
@@ -41,6 +41,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneSafelinkUpdateRuleMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneSafelinkUpdateRuleMethod.swift
@@ -45,6 +45,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneVerificationRevokeVerificationsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneVerificationRevokeVerificationsMethod.swift
@@ -38,6 +38,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneVerificationsGrantVerificationsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneVerificationsGrantVerificationsMethod.swift
@@ -32,6 +32,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountEmailAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountEmailAsAdmin.swift
@@ -39,6 +39,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountHandleAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountHandleAsAdmin.swift
@@ -39,6 +39,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountPasswordAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountPasswordAsAdmin.swift
@@ -36,6 +36,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountSigningKey.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateAccountSigningKey.swift
@@ -30,6 +30,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateCommunicationTemplateAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateCommunicationTemplateAsAdmin.swift
@@ -51,6 +51,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateMemberAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateMemberAsAdmin.swift
@@ -42,6 +42,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateSubjectStatusAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpdateSubjectStatusAsAdmin.swift
@@ -42,6 +42,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpsertOptionAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpsertOptionAsAdmin.swift
@@ -39,6 +39,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpsertSetAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpsertSetAsAdmin.swift
@@ -36,6 +36,7 @@ extension ATProtoAdmin {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetActorFeedsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetActorFeedsMethod.swift
@@ -41,6 +41,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetActorLikesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetActorLikesMethod.swift
@@ -46,6 +46,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedGeneratorMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedGeneratorMethod.swift
@@ -35,6 +35,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedGeneratorsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedGeneratorsMethod.swift
@@ -35,6 +35,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetFeedMethod.swift
@@ -40,6 +40,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetLikesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetLikesMethod.swift
@@ -43,6 +43,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetPostsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetPostsMethod.swift
@@ -38,6 +38,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetQuotesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetQuotesMethod.swift
@@ -43,6 +43,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetRepostedByMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetRepostedByMethod.swift
@@ -43,6 +43,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetSuggestedFeedsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetSuggestedFeedsMethod.swift
@@ -38,6 +38,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetTimelineMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedGetTimelineMethod.swift
@@ -47,6 +47,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedSearchPostsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedSearchPostsMethod.swift
@@ -68,6 +68,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedSendInteractionsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedSendInteractionsMethod.swift
@@ -37,6 +37,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetActorStarterPacksMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetActorStarterPacksMethod.swift
@@ -41,10 +41,11 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.graph.getActorStarterPack") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.graph.getActorStarterPacks") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetBlocksMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetBlocksMethod.swift
@@ -39,6 +39,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetKnownFollowersMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetKnownFollowersMethod.swift
@@ -41,6 +41,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetListBlocksMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetListBlocksMethod.swift
@@ -39,6 +39,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetListMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetListMethod.swift
@@ -41,6 +41,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetListMutesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetListMutesMethod.swift
@@ -39,6 +39,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetListsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetListsMethod.swift
@@ -41,6 +41,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetMutesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetMutesMethod.swift
@@ -39,6 +39,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetStarterPackMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetStarterPackMethod.swift
@@ -29,6 +29,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetStarterPacksMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetStarterPacksMethod.swift
@@ -31,6 +31,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetSuggestedFollowsByActorMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetSuggestedFollowsByActorMethod.swift
@@ -35,6 +35,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphMuteActorListMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphMuteActorListMethod.swift
@@ -31,6 +31,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphMuteActorMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphMuteActorMethod.swift
@@ -31,6 +31,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphMuteThreadMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphMuteThreadMethod.swift
@@ -32,6 +32,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphUnmuteActorListMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphUnmuteActorListMethod.swift
@@ -31,6 +31,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphUnmuteActorMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphUnmuteActorMethod.swift
@@ -31,6 +31,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphUnmuteThreadMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphUnmuteThreadMethod.swift
@@ -31,6 +31,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationGetPreferencesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationGetPreferencesMethod.swift
@@ -31,6 +31,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationGetUnreadCountMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationGetUnreadCountMethod.swift
@@ -41,6 +41,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationListNotificationsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationListNotificationsMethod.swift
@@ -51,6 +51,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationPutActivitySubscriptionMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationPutActivitySubscriptionMethod.swift
@@ -38,6 +38,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationPutPreferencesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationPutPreferencesMethod.swift
@@ -31,6 +31,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationPutPreferencesV2Method.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationPutPreferencesV2Method.swift
@@ -41,6 +41,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationRegisterPushMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationRegisterPushMethod.swift
@@ -42,6 +42,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationUnregisterPushMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationUnregisterPushMethod.swift
@@ -41,6 +41,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationUpdateSeenMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationUpdateSeenMethod.swift
@@ -32,6 +32,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationsListActivitySubscriptionsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationsListActivitySubscriptionsMethod.swift
@@ -40,6 +40,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedCheckHandleAvailabilityMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedCheckHandleAvailabilityMethod.swift
@@ -44,6 +44,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetAgeAssuranceStateMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetAgeAssuranceStateMethod.swift
@@ -35,6 +35,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetConfigMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetConfigMethod.swift
@@ -34,6 +34,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetPopularFeedGeneratorsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetPopularFeedGeneratorsMethod.swift
@@ -43,6 +43,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedFeedsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedFeedsMethod.swift
@@ -34,6 +34,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedFeedsSkeletonMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedFeedsSkeletonMethod.swift
@@ -40,6 +40,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedStarterPacksMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedStarterPacksMethod.swift
@@ -34,10 +34,11 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.unspecced.getSuggestedFeedsSkeleton") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.unspecced.getSuggestedStarterPacks") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedStarterPacksSkeletonMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedStarterPacksSkeletonMethod.swift
@@ -40,6 +40,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedUsersMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedUsersMethod.swift
@@ -39,6 +39,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedUsersSkeletonMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestedUsersSkeletonMethod.swift
@@ -38,6 +38,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestionsSkeletonMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetSuggestionsSkeletonMethod.swift
@@ -50,6 +50,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTrendingTopicsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTrendingTopicsMethod.swift
@@ -43,6 +43,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTrendsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTrendsMethod.swift
@@ -34,6 +34,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTrendsSkeletonMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTrendsSkeletonMethod.swift
@@ -40,6 +40,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedInitAgeAssuranceMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedInitAgeAssuranceMethod.swift
@@ -42,6 +42,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentityRequestPlcOperationSignatureMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentityRequestPlcOperationSignatureMethod.swift
@@ -29,6 +29,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentitySignPlcOperationMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentitySignPlcOperationMethod.swift
@@ -46,6 +46,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentityUpdateHandleMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentityUpdateHandleMethod.swift
@@ -32,6 +32,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoModerationCreateReportMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoModerationCreateReportMethod.swift
@@ -40,6 +40,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoApplyWritesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoApplyWritesMethod.swift
@@ -40,6 +40,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoCreateRecordMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoCreateRecordMethod.swift
@@ -51,6 +51,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoDeleteRecordMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoDeleteRecordMethod.swift
@@ -44,6 +44,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoListMissingBlobsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoListMissingBlobsMethod.swift
@@ -38,6 +38,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoPutRecordMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoPutRecordMethod.swift
@@ -50,6 +50,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerActivateAccountMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerActivateAccountMethod.swift
@@ -30,6 +30,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerCheckAccountStatusMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerCheckAccountStatusMethod.swift
@@ -35,6 +35,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerConfirmEmailMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerConfirmEmailMethod.swift
@@ -43,6 +43,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerCreateAppPasswordMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerCreateAppPasswordMethod.swift
@@ -41,6 +41,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerCreateInviteCodeMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerCreateInviteCodeMethod.swift
@@ -40,6 +40,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerCreateInviteCodesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerCreateInviteCodesMethod.swift
@@ -36,6 +36,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerDeactivateAccountMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerDeactivateAccountMethod.swift
@@ -36,6 +36,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerGetAccountInviteCodesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerGetAccountInviteCodesMethod.swift
@@ -39,6 +39,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerGetServiceAuthMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerGetServiceAuthMethod.swift
@@ -41,6 +41,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerListAppPasswordsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerListAppPasswordsMethod.swift
@@ -33,6 +33,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerRequestAccountDeleteMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerRequestAccountDeleteMethod.swift
@@ -32,6 +32,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerRequestEmailConfirmationMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerRequestEmailConfirmationMethod.swift
@@ -29,6 +29,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerRequestEmailUpdateMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerRequestEmailUpdateMethod.swift
@@ -31,6 +31,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerRevokeAppPasswordMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerRevokeAppPasswordMethod.swift
@@ -31,6 +31,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerUpdateEmailMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoServerUpdateEmailMethod.swift
@@ -42,6 +42,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoTempAddReservedHandleMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoTempAddReservedHandleMethod.swift
@@ -34,6 +34,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoTempRequestPhoneVerificationMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoTempRequestPhoneVerificationMethod.swift
@@ -37,6 +37,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
 
         guard let sessionURL = session.pdsURL,

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComStprotoServerDeleteAccountMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComStprotoServerDeleteAccountMethod.swift
@@ -40,6 +40,7 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
+        try await sessionConfiguration?.ensureValidToken()
         let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 

--- a/Sources/ATProtoKit/ATProtoKit.swift
+++ b/Sources/ATProtoKit/ATProtoKit.swift
@@ -61,8 +61,10 @@ extension ATProtoKitConfiguration {
         // Check if the session exists and has a valid access token.
         if let sessionConfiguration = sessionConfiguration {
             do {
-                let keychain = try await sessionConfiguration.keychainProtocol.retrieveAccessToken()
-                return "Bearer \(keychain)"
+                // Ensure token is valid before retrieving it
+                try await sessionConfiguration.ensureValidToken()
+                let accessToken = try await sessionConfiguration.keychainProtocol.retrieveAccessToken()
+                return "Bearer \(accessToken)"
             } catch {
                 return nil
             }


### PR DESCRIPTION
⚠️ This PR depends on #209 and should be merged after it.
I propose to merge it once this PR is reviewed and once #209 is tested even on production.

### Summary
This PR implements automatic token refresh functionality across all authentication-required methods in ATProtoKit. Building on the foundation established in PR #209 , this completes the implementation by adding proactive token validation to all 142 auth-required methods throughout the library.

### Problem
Users were experiencing `ExpiredToken` errors after 2 hours of inactivity when their access tokens expired. This required manual intervention to refresh tokens, leading to a poor user experience.

### Solution
This PR adds a single line `try await sessionConfiguration?.ensureValidToken()` before retrieving the access token in each authentication-required method. This ensures that:
- Tokens are automatically refreshed when expired
- API calls never fail due to expired tokens
- Users experience seamless operation without manual token management

### Implementation Details

**Methods Updated: 142**
- ✅ Feed Methods (13)
- ✅ Notification Methods (10)
- ✅ Graph Methods (17)
- ✅ Record Operations (3)
- ✅ ComAtproto Methods (21)
- ✅ AppBsky Unspecced Methods (14)
- ✅ Admin/Moderator Methods (60)
- ✅ Tools Methods (9)
- ✅ Video Methods (1 - already handled via getServiceAuthentication)

**Auth-Optional Methods (7)** - Already covered by prepareAuthorizationValue() changes in PR #209 

### Testing
The implementation follows the established pattern from PR #209, which has been tested. Each method now includes the same token refresh logic, ensuring consistent behavior across the entire library.

## Linked Issues
#203 

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.