### PR TITLE
Fix 2FA detection to handle both 400 and 401 AuthFactorTokenRequired responses

### DIFF
--- a/Sources/ATProtoKit/APIReference/SessionManager/SessionConfiguration.swift
+++ b/Sources/ATProtoKit/APIReference/SessionManager/SessionConfiguration.swift
@@ -112,6 +112,9 @@ public protocol SessionConfiguration: AnyObject, Sendable {
     /// while adding the password and tokens to the `keychainProtocol` instance. Additional
     /// Two-Factor Authentication implementations must be handled as well.
     ///
+    /// - Note: 2FA detection now supports both `.badRequest` (400) and `.unauthorized` (401)
+    /// responses containing the `AuthFactorTokenRequired` error.
+    ///
     /// - Parameters:
     ///   - handle: The hanle used for the account.
     ///   - password: The password used for the account.


### PR DESCRIPTION
## Description
This PR fixes a gap in SessionConfiguration’s 2FA detection logic.

Previously, 2FA requirements were only detected via .badRequest (HTTP 400) responses containing AuthFactorTokenRequired. Some servers return the same requirement as .unauthorized (HTTP 401). This change adds handling for that case, ensuring the 2FA flow continues correctly regardless of status code.

The update also includes corresponding inline documentation clarifying that both response types are supported.

## Linked Issues
N/A

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [x] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Rayan Waked]
- GitHub: [rayanwaked]
- Bluesky: [skyliner.app]
- Email: [rayan@waked.dev]
