### PR TITLE
Fixed lexicons (activeProgressGuide & PLC Operation) and api methods per specifications

### DIFF
--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentitySignPlcOperationMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentitySignPlcOperationMethod.swift
@@ -38,8 +38,8 @@ extension ATProtoKit {
         token: String,
         rotationKeys: [String]? = nil,
         alsoKnownAs: [String]? = nil,
-        verificationMethods: VerificationMethod?,
-        service: ATService?
+        verificationMethods: [String:String]?,
+        services: [String: ComAtprotoLexicon.Identity.PLCOperationATService]?
     ) async throws -> ComAtprotoLexicon.Identity.SignPLCOperationOutput {
         guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
@@ -59,7 +59,7 @@ extension ATProtoKit {
             rotationKeys: rotationKeys,
             alsoKnownAs: alsoKnownAs,
             verificationMethods: verificationMethods,
-            service: service
+            services: services
         )
 
         do {

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentitySubmitPlcOperationMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentitySubmitPlcOperationMethod.swift
@@ -26,7 +26,7 @@ extension ATProtoKit {
     ///
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
-    public func submitPLCOperation(_ operation: UnknownType) async throws {
+    public func submitPLCOperation(_ operation: ComAtprotoLexicon.Identity.SignedPLCOperation) async throws {
         guard let requestURL = URL(string: "\(self.pdsURL)/xrpc/com.atproto.identity.submitPlcOperation") else {
             throw ATRequestPrepareError.invalidRequestURL
         }

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
@@ -1488,7 +1488,7 @@ extension AppBskyLexicon.Actor {
         public let type: String = "app.bsky.actor.defs#bskyAppStatePref"
 
         /// An active progress guide. Optional.
-        public let activeProgressGuide: String?
+        public let activeProgressGuide: BskyAppProgressGuideDefinition?
 
         /// An array of elements that the user will see. Optional.
         ///
@@ -1531,13 +1531,23 @@ extension AppBskyLexicon.Actor {
         /// The progress guide itself.
         ///
         /// - Important: Current maximum length is 100 characters.
-        public let guide: [BskyAppStatePreferencesDefinition]
-
+        public let guide: String
+        
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.guide = try container.decode(String.self, forKey: .guide)
+        }
+        
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
 
             try container.truncatedEncode(self.guide, forKey: .guide, upToArrayLength: 100)
         }
+        
+        enum CodingKeys: CodingKey {
+            case guide
+        }
+
     }
 
     /// A definition model for a NUX.

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Identity/ComAtprotoIdentitySignPLCOperation.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Identity/ComAtprotoIdentitySignPLCOperation.swift
@@ -30,16 +30,61 @@ extension ComAtprotoLexicon.Identity {
         public let token: String?
 
         /// The rotation keys recommended to be added in the DID document. Optional.
+        /// An array of aliases of the user account. Optional.
+        /// - Important: To add a new rotation key, include all existing rotation keys with the new
+        /// rotation key.
+        ///
+        /// - Important: To remove a rotation key, include all existing rotation keys except the
+        /// rotation key being removed.
         public let rotationKeys: [String]?
 
         /// An array of aliases of the user account. Optional.
+        /// - Important: To add a new alias, include all existing aliases with the new alias.
+        ///
+        /// - Important: To remove an alias, include all existing alias' except the alias being removed.
         public let alsoKnownAs: [String]?
 
-        /// A verification method recommeneded to be added in the DID document. Optional.
-        public let verificationMethods: VerificationMethod?
+        /// A dictionary of verification methods to inckude in the DID document. Optional.
+        /// - Important: To add a new verification method, include all existing verification methods with the
+        /// new verification method.
+        ///
+        /// - Important: To remove a verification method, include all existing verification methods except the
+        /// verification method being removed.
+        public let verificationMethods: [String: String]? //VerificationMethod?
 
-        /// The service endpoint recommended in the DID document. Optional.
-        public let service: ATService?
+        /// A dictionary of service endpoints to include in the DID document. Optional.
+        /// - Important: To add a new service endpoint, include all existing service endpoints with the
+        /// new service endpoint.
+        ///
+        /// - Important: To remove a service endpoint, include all existing service endpoints except the
+        /// service endpoint being removed.
+        public let services: [String: PLCOperationATService]? //ATService?
+        
+        public init(token: String?, rotationKeys: [String]?, alsoKnownAs: [String]?, verificationMethods: [String : String]?, services: [String : PLCOperationATService]?) {
+            self.token = token
+            self.rotationKeys = rotationKeys
+            self.alsoKnownAs = alsoKnownAs
+            self.verificationMethods = verificationMethods
+            self.services = services
+        }
+        
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            
+            try container.encodeIfPresent(self.token, forKey: .token)
+            try container.encodeIfPresent(self.rotationKeys, forKey: .rotationKeys)
+            try container.encodeIfPresent(self.alsoKnownAs, forKey: .alsoKnownAs)
+            try container.encodeIfPresent(self.verificationMethods, forKey: .verificationMethods)
+            try container.encodeIfPresent(self.services, forKey: .services)
+        }
+        
+        enum CodingKeys: String, CodingKey {
+            case token
+            case rotationKeys
+            case alsoKnownAs
+            case verificationMethods
+            case services
+        }
     }
 
     /// An output model for signing a PLC operation to a DID document.
@@ -53,6 +98,77 @@ extension ComAtprotoLexicon.Identity {
     public struct SignPLCOperationOutput: Sendable, Codable {
 
         /// A signed PLC operation.
-        public let operation: UnknownType
+        public let operation: SignedPLCOperation
+    }
+    
+    /// Represents a service endpoint in a DID document in a PLC operation
+    ///
+    /// - SeeAlso: This is based on the PLC Directory [`CreatePlcOp`][plc].
+    ///
+    /// [plc]: https://web.plc.directory/api/redoc#operation/CreatePlcOp
+    public struct PLCOperationATService: Sendable, Codable {
+
+        /// The type of service.
+        public let type: String
+
+        /// The endpoint URL for the service, specifying the location of the service.
+        public let serviceEndpointURI: String
+        
+        public init(type: String, serviceEndpointURI: String) {
+            self.type = type
+            self.serviceEndpointURI = serviceEndpointURI
+        }
+        
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            
+            self.type = try container.decode(String.self, forKey: .type)
+            self.serviceEndpointURI = try container.decode(String.self, forKey: .serviceEndpointURI)
+        }
+        
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            
+            try container.encode(self.type, forKey: .type)
+            try container.encode(self.serviceEndpointURI, forKey: .serviceEndpointURI)
+        }
+        
+        enum CodingKeys: String, CodingKey {
+            case type
+            case serviceEndpointURI = "endpoint"
+        }
+    }
+    
+    /// Represents a signed PLC operation response
+    ///
+    /// - Note: A signed PLC operation is returned in the response to calling
+    /// [`com.atproto.identity.signPlcOperation`][github]
+    ///
+    /// - SeeAlso: This is based on the PLC Directory [`CreatePlcOp`][plc].
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/identity/signPlcOperation.json
+    /// [plc]: https://web.plc.directory/api/redoc#operation/CreatePlcOp
+    public struct SignedPLCOperation: Sendable, Codable {
+        
+        /// The PLC operation type
+        public let type: String
+
+        /// Ordered set (no duplicates) of cryptographic public keys in did:key format
+        public let rotationKeys: [String]
+
+        /// Map (object) of application-specific cryptographic public keys in did:key format
+        public let verificationMethods: [String: String]
+
+        /// Ordered set (no duplicates) of aliases and names for this account, in the form of URIs
+        public let alsoKnownAs: [String]
+
+        /// Map (object) of application-specific service endpoints for this account
+        public let services: [String: PLCOperationATService]
+
+        /// Strong reference (hash) of preceeding operation for this DID, in string CID format. Null for genesis operation
+        public let prev: String
+       
+        /// Cryptographic signature of this object, with base64 string encoding
+        public let sig: String
     }
 }

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Identity/ComAtprotoIdentitySubmitPLCOperation.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Identity/ComAtprotoIdentitySubmitPLCOperation.swift
@@ -24,6 +24,6 @@ extension ComAtprotoLexicon.Identity {
     public struct SubmitPLCOperationRequestBody: Sendable, Codable {
 
         /// A PLC operation.
-        public let operation: UnknownType
+        public let operation: SignedPLCOperation
     }
 }


### PR DESCRIPTION
Fixed 2 lexicon issues:
1. Preferences `activeProgressGuide` property
2. PLC Operation lexicons and api where incomplete for performing an update to the PLC Directory. These changes align the lexicons and api with the specifications. Includes  proper comments, public init, decode, encode methods too.

## Description
Performing a PLC Operation update was not possible due to incorrect lexicons and api signatures.

## Type of Change
- [X] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [X] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [X] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [X] My code is able to build and run on my machine.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: Scott Handley
- GitHub: mcprostar205
- Bluesky: h2oskier.bsky.social
