### PR TITLE
Added "Equatable" protocol to AppBskyLexicon.Notification.Notificatio…

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
@@ -1659,16 +1659,16 @@ extension AppBskyLexicon.Actor {
         /// - Note: According to the AT Protocol specifications: "Matches threadgate record. List of rules
         /// defining who can reply to this users posts. If value is an empty array, no one can reply. If
         /// value is undefined, anyone can reply."
-        public let threadgateAllowRules: [ThreadgateAllowRulesUnion]
+        public let threadgateAllowRules: [ThreadgateAllowRulesUnion]?
 
         /// An array of rules that determines the default settings for determining who can embed the post.
         ///
         /// - Note: According to the AT Protocol specifications: "Matches postgate record. List of rules
         /// defining who can embed this users posts. If value is an empty array or is undefined, no
         /// particular rules apply and anyone can embed."
-        public let postgateEmbeddingRules: [PostgateEmbeddingRulesUnion]
+        public let postgateEmbeddingRules: [PostgateEmbeddingRulesUnion]?
 
-        public init(threadgateAllowRules: [ThreadgateAllowRulesUnion], postgateEmbeddingRules: [PostgateEmbeddingRulesUnion]) {
+        public init(threadgateAllowRules: [ThreadgateAllowRulesUnion]? = nil, postgateEmbeddingRules: [PostgateEmbeddingRulesUnion]? = nil) {
             self.threadgateAllowRules = threadgateAllowRules
             self.postgateEmbeddingRules = postgateEmbeddingRules
         }
@@ -1676,15 +1676,15 @@ extension AppBskyLexicon.Actor {
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
 
-            self.threadgateAllowRules = try container.decode([ThreadgateAllowRulesUnion].self, forKey: .threadgateAllowRules)
-            self.postgateEmbeddingRules = try container.decode([PostgateEmbeddingRulesUnion].self, forKey: .postgateEmbeddingRules)
+            self.threadgateAllowRules = try container.decodeIfPresent([ThreadgateAllowRulesUnion].self, forKey: .threadgateAllowRules)
+            self.postgateEmbeddingRules = try container.decodeIfPresent([PostgateEmbeddingRulesUnion].self, forKey: .postgateEmbeddingRules)
         }
 
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
 
-            try container.truncatedEncode(self.threadgateAllowRules, forKey: .threadgateAllowRules, upToArrayLength: 5)
-            try container.truncatedEncode(self.postgateEmbeddingRules, forKey: .postgateEmbeddingRules, upToArrayLength: 5)
+            try container.truncatedEncodeIfPresent(self.threadgateAllowRules, forKey: .threadgateAllowRules, upToArrayLength: 5)
+            try container.truncatedEncodeIfPresent(self.postgateEmbeddingRules, forKey: .postgateEmbeddingRules, upToArrayLength: 5)
         }
 
         enum CodingKeys: String, CodingKey {

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Notification/AppBskyNotificationListNotifications.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Notification/AppBskyNotificationListNotifications.swift
@@ -159,7 +159,7 @@ extension AppBskyLexicon.Notification {
 
         // Enums
         /// The kind of notification received.
-        public enum Reason: Sendable, Codable, ExpressibleByStringLiteral {
+        public enum Reason: Sendable, Codable, Equatable, ExpressibleByStringLiteral {
 
             /// Indicates the notification is about someone liking a post from the user account.
             case like


### PR DESCRIPTION
## Description
Notifications lexicon was missing the Equatable protocol making use within a ForEach loop impossible.

Added: Fixed app.bsky.actor lexicon decoding error in PostInteractionSettingsPreferenceDefinition

## Linked Issues
Link any related issues here. Format: `#[issue number]`

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [X ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [X ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X ] My changes generate no new warnings or errors in the compiler or runtime.
- [X ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
