### PR TITLE
Added more missing public initializers

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorPutPreferences.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorPutPreferences.swift
@@ -30,6 +30,10 @@ extension AppBskyLexicon.Actor {
         /// A list of preferences by the user.
         public let preferences: [AppBskyLexicon.Actor.PreferenceUnion]
 
+        public init(preferences: [AppBskyLexicon.Actor.PreferenceUnion]) {
+            self.preferences = preferences
+        }
+        
         enum CodingKeys: String, CodingKey {
             case type = "$type"
             case preferences

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Repo/ComAtprotoRepoCreateRecord.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Repo/ComAtprotoRepoCreateRecord.swift
@@ -59,6 +59,15 @@ extension ComAtprotoLexicon.Repository {
         /// commit by CID."
         public let swapCommit: String?
 
+        public init(repositoryDID: String, collection: String, recordKey: String? = nil, shouldValidate: Bool? = nil, record: UnknownType, swapCommit: String? = nil) {
+            self.repositoryDID = repositoryDID
+            self.collection = collection
+            self.recordKey = recordKey
+            self.shouldValidate = shouldValidate
+            self.record = record
+            self.swapCommit = swapCommit
+        }
+        
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
 

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Repo/ComAtprotoRepoDeleteRecord.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Repo/ComAtprotoRepoDeleteRecord.swift
@@ -53,6 +53,23 @@ extension ComAtprotoLexicon.Repository {
         /// previous commit by CID."
         public let swapCommit: String?
 
+        public init(repositoryDID: String, collection: String, recordKey: String, swapRecord: String?, swapCommit: String?) {
+            self.repositoryDID = repositoryDID
+            self.collection = collection
+            self.recordKey = recordKey
+            self.swapRecord = swapRecord
+            self.swapCommit = swapCommit
+        }
+        
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(self.repositoryDID, forKey: .repositoryDID)
+            try container.encode(self.collection, forKey: .collection)
+            try container.encode(self.recordKey, forKey: .recordKey)
+            try container.encodeIfPresent(self.swapRecord, forKey: .swapRecord)
+            try container.encodeIfPresent(self.swapCommit, forKey: .swapCommit)
+        }
+        
         enum CodingKeys: String, CodingKey {
             case repositoryDID = "repo"
             case collection

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerCreateSession.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerCreateSession.swift
@@ -62,6 +62,19 @@ extension ComAtprotoLexicon.Server {
         /// A token used for Two-Factor Authentication. Optional.
         let authenticationFactorToken: String?
 
+        public init(identifier: String, password: String, authenticationFactorToken: String?) {
+            self.identifier = identifier
+            self.password = password
+            self.authenticationFactorToken = authenticationFactorToken
+        }
+        
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(self.identifier, forKey: .identifier)
+            try container.encode(self.password, forKey: .password)
+            try container.encodeIfPresent(self.authenticationFactorToken, forKey: .authenticationFactorToken)
+        }
+        
         enum CodingKeys: String, CodingKey {
             case identifier
             case password


### PR DESCRIPTION
ComAtprotoRepoCreateRecord
PreferenceUnion
CreateSessionRequestBody
DeleteRecordRequestBody

## Description
Unable to create instances of lexicons that are missing public initializers. 

## Linked Issues
Link any related issues here. Format: `#[issue number]`

## Type of Change
- [X ] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [X ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [X ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X ] My changes generate no new warnings or errors in the compiler or runtime.
- [X ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
