### PR TITLE
Fix registerPush and unregisterPush Content-Type header

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationRegisterPushMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationRegisterPushMethod.swift
@@ -63,7 +63,7 @@ extension ATProtoKit {
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
-                contentTypeValue: nil,
+                contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationUnregisterPushMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyNotificationUnregisterPushMethod.swift
@@ -61,7 +61,7 @@ extension ATProtoKit {
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
-                contentTypeValue: nil,
+                contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
 


### PR DESCRIPTION
## Summary

Fixes Content-Type header for `registerPush` and `unregisterPush` endpoints to resolve "Wrong request encoding" errors.

## Changes

- Set `contentTypeValue: "application/json"` (was `nil`) in `AppBskyNotificationRegisterPushMethod.swift`
- Set `contentTypeValue: "application/json"` (was `nil`) in `AppBskyNotificationUnregisterPushMethod.swift`

## Problem

The `registerPush` and `unregisterPush` methods were passing `contentTypeValue: nil` to `createRequest()`, which caused the `Content-Type` header to not be set. While the request body was correctly JSON-encoded via `toJsonData()`, the missing header caused PDS to reject requests with a 400 "Wrong request encoding" error.

## Solution

Explicitly set `contentTypeValue` to `"application/json"` to ensure the correct Content-Type header is sent with the request.

## Testing

- Push notification registration now works correctly without 400 errors
- Follows the same pattern as other POST methods like `putPreferences`