### PR TITLE
Update keychain setting to allow access in background

### DIFF
--- a/Sources/ATProtoKit/APIReference/SessionManager/AppleSecureKeychain.swift
+++ b/Sources/ATProtoKit/APIReference/SessionManager/AppleSecureKeychain.swift
@@ -181,6 +181,13 @@ public actor AppleSecureKeychain: SecureKeychainProtocol {
 
     /// Saves or updates a keychain item.
     ///
+    /// Items are stored with `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` so that
+    /// background tasks (e.g. push-driven refresh) can read session tokens while the device
+    /// is locked. Without this attribute, the keychain default is `kSecAttrAccessibleWhenUnlocked`,
+    /// which causes `SecItemCopyMatching` to return `errSecInteractionNotAllowed` for any
+    /// access attempted while the screen is locked — silently breaking background refresh.
+    /// `ThisDeviceOnly` prevents tokens from migrating via iCloud Keychain or encrypted backups.
+    ///
     /// - Parameters:
     ///   - value: The keychain value.
     ///   - key: The keychain key.
@@ -195,8 +202,13 @@ public actor AppleSecureKeychain: SecureKeychainProtocol {
             kSecAttrService: serviceName,
         ]
 
+        // Including `kSecAttrAccessible` in the update dictionary upgrades the accessibility
+        // of items previously written with the default attribute, so existing installs
+        // migrate to the background-readable policy on the next save without needing a
+        // delete+re-add cycle.
         let updateAttributes: [CFString: Any] = [
-            kSecValueData: data
+            kSecValueData: data,
+            kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         ]
 
         let status = SecItemUpdate(query as CFDictionary, updateAttributes as CFDictionary)
@@ -207,6 +219,7 @@ public actor AppleSecureKeychain: SecureKeychainProtocol {
             case errSecItemNotFound:
                 var newItem = query
                 newItem[kSecValueData] = data
+                newItem[kSecAttrAccessible] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
                 let addStatus = SecItemAdd(newItem as CFDictionary, nil)
                 guard addStatus == errSecSuccess else {
                     throw ApplSecureKeychainError.unhandledStatus(status: addStatus)


### PR DESCRIPTION
## Description
In my upcoming app, the device performs periodic background refreshes of data from Bluesky. I've recently determined that these refreshes are failing because of the keychain policy, which by default blocks access to the tokens stored in Keychain when the device is in the background. This update adds a specification to the keychain storage that permits background access after the user has unlocked their device at least once (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`).

I think this is a reasonable default because it still requires user auth before access, and matches the use case that Apple provides in their docs:

"After the first unlock, the data remains accessible until the next restart. This is recommended for items that need to be accessed by background applications. Items with this attribute do not migrate to a new device. Thus, after restoring from a backup of a different device, these items will not be present."

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

