### PR TITLE
Include record view for handling chat record defs

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Convo/ChatBskyConvoDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Convo/ChatBskyConvoDefs.swift
@@ -217,7 +217,7 @@ extension ChatBskyLexicon.Conversation {
                 let type = try container.decodeIfPresent(String.self, forKey: .type)
 
                 switch type {
-                    case "app.bsky.embed.record":
+                    case "app.bsky.embed.record", "app.bsky.embed.record#view":
                         self = .recordView(try AppBskyLexicon.Embed.RecordDefinition.View(from: decoder))
                     default:
                         let singleValueDecodingContainer = try decoder.singleValueContainer()


### PR DESCRIPTION
## Description
When a DM includes a post record in the message, the parser was falling through because it wasn't looking for `app.bsky.embed.record#view`, which is what it receives. It was handling `app.bsky.embed.record` only.

This just adds the additional view to the conditional so it can render a post in a DM chat.
