### PR TITLE
Handle upload blob output correctly

### DIFF
--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoUploadBlobMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoUploadBlobMethod.swift
@@ -52,12 +52,22 @@ extension ATProtoKit {
                 authorizationValue: "Bearer \(accessToken)")
             request.httpBody = imageData
 
+            // The `com.atproto.repo.uploadBlob` endpoint wraps its result in a
+            // `blob` key (`{"blob": {...}}`), unlike record fields where the blob
+            // appears inline. Decode the wrapper and return its blob so uploads
+            // don't fail looking for `ref` at the response root.
             let response = try await apiClientService.sendRequest(request,
-                                                      decodeTo: ComAtprotoLexicon.Repository.UploadBlobOutput.self)
+                                                      decodeTo: UploadBlobResponse.self)
 
-            return response
+            return response.blob
         } catch {
             throw error
         }
     }
+}
+
+/// The response envelope for `com.atproto.repo.uploadBlob`, which returns the
+/// uploaded blob under a `blob` key.
+private struct UploadBlobResponse: Decodable {
+    let blob: ComAtprotoLexicon.Repository.UploadBlobOutput
 }


### PR DESCRIPTION
## Description
Posting to Bluesky with media is causing a decode error:

```
Printing description of error:
▿ DecodingError.keyNotFound: Key 'ref' not found in keyed decoding container. Debug description: No value associated with key CodingKeys(stringValue: "ref", intValue: nil) ("ref").
  ▿ keyNotFound : 2 elements
    - .0 : CodingKeys(stringValue: "ref", intValue: nil)
    ▿ .1 : Context
      - codingPath : 0 elements
      - debugDescription : "No value associated with key CodingKeys(stringValue: \"ref\", intValue: nil) (\"ref\")."
      - underlyingError : nil
```

This provides the mechanism for decoding the uploaded blobs