### PR TITLE
Implement app.bsky.embed.gallery lexicon

### DIFF
--- a/Sources/ATProtoKit/Models/Common/ATRecordViewProtocol/ATRecordViewProtocolExtensions.swift
+++ b/Sources/ATProtoKit/Models/Common/ATRecordViewProtocol/ATRecordViewProtocolExtensions.swift
@@ -136,6 +136,8 @@ extension AppBskyLexicon.Embed.RecordDefinition.ViewRecord.EmbedsUnion: Identifi
                 return view.id
             case .embedVideoView(let view):
                 return view.id
+            case .embedGalleryView(let view):
+                return view.id
             case .unknown(_, let dictionary):
                 return String(dictionary.hashValue)
         }
@@ -155,6 +157,18 @@ extension AppBskyLexicon.Embed.ImagesDefinition.View: Identifiable {
 }
 
 extension AppBskyLexicon.Embed.ImagesDefinition.ViewImage: Identifiable {
+    public var id: String {
+        return "\(self.fullSizeImageURL)_\(self.thumbnailImageURL)"
+    }
+}
+
+extension AppBskyLexicon.Embed.GalleryDefinition.View: Identifiable {
+    public var id: String {
+        return items.map(\.id).joined(separator: "_")
+    }
+}
+
+extension AppBskyLexicon.Embed.GalleryDefinition.ViewImage: Identifiable {
     public var id: String {
         return "\(self.fullSizeImageURL)_\(self.thumbnailImageURL)"
     }
@@ -220,6 +234,8 @@ extension AppBskyLexicon.Embed.RecordWithMediaDefinition.View: Identifiable {
             case .embedImagesView(let mediaView):
                 return mediaView.id
             case .embedVideoView(let mediaView):
+                return mediaView.id
+            case .embedGalleryView(let mediaView):
                 return mediaView.id
             case .unknown(_, let dictionary):
                 return String(dictionary.hashValue)

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
@@ -1,0 +1,151 @@
+//
+//  AppBskyEmbedGallery.swift
+//
+//
+//  Created on 2026-06-08.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Embed {
+
+    /// A definition model for gallery embeds.
+    ///
+    /// - Note: According to the AT Protocol specifications: "A set of images embedded in a Bluesky
+    /// record (eg, a post). Successor to `app.bsky.embed.images`, supporting a larger number
+    /// of images per post."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.embed.gallery`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/gallery.json
+    public struct GalleryDefinition: Sendable, Codable, Equatable, Hashable {
+
+        /// The identifier of the lexicon.
+        ///
+        /// - Warning: The value must not change.
+        public let type: String = "app.bsky.embed.gallery"
+
+        public init() {}
+
+        public init(from decoder: any Decoder) throws {}
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(self.type, forKey: CodingKeys.type)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case type = "$type"
+        }
+
+        // Enums
+        /// A data model for the embed gallery view definition.
+        ///
+        /// - SeeAlso: This is based on the [`app.bsky.embed.gallery`][github] lexicon.
+        ///
+        /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/gallery.json
+        public struct View: Sendable, Codable, Equatable, Hashable {
+
+            /// The identifier of the lexicon.
+            ///
+            /// - Warning: The value must not change.
+            public let type: String = "app.bsky.embed.gallery#view"
+
+            /// An array of images.
+            public let items: [ViewImage]
+
+            public init(items: [ViewImage]) {
+                self.items = items
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+
+                self.items = try container.decode([AppBskyLexicon.Embed.GalleryDefinition.ViewImage].self, forKey: .items)
+            }
+
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+
+                try container.encode(self.type, forKey: .type)
+                try container.encode(self.items, forKey: .items)
+            }
+
+            public enum CodingKeys: String, CodingKey {
+                case type = "$type"
+                case items
+            }
+        }
+
+        /// A data model for a definition related to viewing a gallery image.
+        ///
+        /// - SeeAlso: This is based on the [`app.bsky.embed.gallery`][github] lexicon.
+        ///
+        /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/gallery.json
+        public struct ViewImage: Sendable, Codable, Equatable, Hashable {
+
+            /// The identifier of the lexicon.
+            ///
+            /// - Warning: The value must not change.
+            public let type: String = "app.bsky.embed.gallery#viewImage"
+
+            /// The URI of the image's thumbnail.
+            ///
+            /// - Note: From the AT Protocol specification: "Fully-qualified URL where a thumbnail
+            /// of the image can be fetched. For example, CDN location provided by the App View."
+            public let thumbnailImageURL: URL
+
+            /// The URI of the fully-sized image.
+            ///
+            /// - Note: From the AT Protocol specification: "Fully-qualified URL where a large
+            /// version of the image can be fetched. May or may not be the exact original blob.
+            /// For example, CDN location provided by the App View."
+            public let fullSizeImageURL: URL
+
+            /// The alternative text for the image.
+            ///
+            /// - Note: From the AT Protocol specification: "Alt text description of the image,
+            /// for accessibility."
+            public let altText: String
+
+            /// The aspect ratio of the image. Optional.
+            public let aspectRatio: AspectRatioDefinition?
+
+            public init(thumbnailImageURL: URL, fullSizeImageURL: URL, altText: String, aspectRatio: AspectRatioDefinition?) {
+                self.thumbnailImageURL = thumbnailImageURL
+                self.fullSizeImageURL = fullSizeImageURL
+                self.altText = altText
+                self.aspectRatio = aspectRatio
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.thumbnailImageURL = try container.decode(URL.self, forKey: CodingKeys.thumbnailImageURL)
+                self.fullSizeImageURL = try container.decode(URL.self, forKey: CodingKeys.fullSizeImageURL)
+                self.altText = try container.decode(String.self, forKey: CodingKeys.altText)
+                self.aspectRatio = try container.decodeIfPresent(AppBskyLexicon.Embed.AspectRatioDefinition.self, forKey: CodingKeys.aspectRatio)
+            }
+
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+
+                try container.encode(self.type, forKey: .type)
+                try container.encode(self.thumbnailImageURL, forKey: .thumbnailImageURL)
+                try container.encode(self.fullSizeImageURL, forKey: .fullSizeImageURL)
+                try container.encode(self.altText, forKey: .altText)
+                try container.encodeIfPresent(self.aspectRatio, forKey: .aspectRatio)
+            }
+
+            enum CodingKeys: String, CodingKey {
+                case type = "$type"
+                case thumbnailImageURL = "thumbnail"
+                case fullSizeImageURL = "fullsize"
+                case altText = "alt"
+                case aspectRatio
+            }
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedRecord.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedRecord.swift
@@ -291,6 +291,9 @@ extension AppBskyLexicon.Embed {
                 /// The view of a video embed.
                 case embedVideoView(AppBskyLexicon.Embed.VideoDefinition.View)
 
+                /// The view of a gallery embed.
+                case embedGalleryView(AppBskyLexicon.Embed.GalleryDefinition.View)
+
                 /// An unknown case.
                 case unknown(String, [String: CodableValue])
 
@@ -303,6 +306,8 @@ extension AppBskyLexicon.Embed {
                             self = .embedExternalView(try AppBskyLexicon.Embed.ExternalDefinition.View(from: decoder))
                         case "app.bsky.embed.images#view":
                             self = .embedImagesView(try AppBskyLexicon.Embed.ImagesDefinition.View(from: decoder))
+                        case "app.bsky.embed.gallery#view":
+                            self = .embedGalleryView(try AppBskyLexicon.Embed.GalleryDefinition.View(from: decoder))
                         case "app.bsky.embed.video#view":
                             self = .embedVideoView(try AppBskyLexicon.Embed.VideoDefinition.View(from: decoder))
                         case "app.bsky.embed.record#view":
@@ -331,6 +336,8 @@ extension AppBskyLexicon.Embed {
                         case .embedRecordWithMediaView(let value):
                             try container.encode(value)
                         case .embedVideoView(let value):
+                            try container.encode(value)
+                        case .embedGalleryView(let value):
                             try container.encode(value)
                         default:
                             break

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedRecordWithMedia.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedRecordWithMedia.swift
@@ -168,6 +168,9 @@ extension AppBskyLexicon.Embed {
                 /// An external link that's been embedded.
                 case embedExternalView(AppBskyLexicon.Embed.ExternalDefinition.View)
 
+                /// A gallery that's been embedded.
+                case embedGalleryView(AppBskyLexicon.Embed.GalleryDefinition.View)
+
                 /// An unknown case.
                 case unknown(String, [String: CodableValue])
 
@@ -182,6 +185,8 @@ extension AppBskyLexicon.Embed {
                             self = .embedVideoView(try AppBskyLexicon.Embed.VideoDefinition.View(from: decoder))
                         case "app.bsky.embed.external#view":
                             self = .embedExternalView(try AppBskyLexicon.Embed.ExternalDefinition.View(from: decoder))
+                        case "app.bsky.embed.gallery#view":
+                            self = .embedGalleryView(try AppBskyLexicon.Embed.GalleryDefinition.View(from: decoder))
                         default:
                             let singleValueDecodingContainer = try decoder.singleValueContainer()
                             let dictionary = try Self.decodeDictionary(from: singleValueDecodingContainer, decoder: decoder)
@@ -199,6 +204,8 @@ extension AppBskyLexicon.Embed {
                         case .embedVideoView(let value):
                             try container.encode(value)
                         case .embedExternalView(let value):
+                            try container.encode(value)
+                        case .embedGalleryView(let value):
                             try container.encode(value)
                         default:
                             break

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedDefs.swift
@@ -143,6 +143,9 @@ extension AppBskyLexicon.Feed {
             /// The view of a record embed alongside an embed of some compatible media.
             case embedRecordWithMediaView(AppBskyLexicon.Embed.RecordWithMediaDefinition.View)
 
+            /// The view of a gallery embed.
+            case embedGalleryView(AppBskyLexicon.Embed.GalleryDefinition.View)
+
             /// An unknown case.
             case unknown(String, [String: CodableValue])
 
@@ -161,6 +164,8 @@ extension AppBskyLexicon.Feed {
                         self = .embedRecordView(try AppBskyLexicon.Embed.RecordDefinition.View(from: decoder))
                     case "app.bsky.embed.recordWithMedia#view":
                         self = .embedRecordWithMediaView(try AppBskyLexicon.Embed.RecordWithMediaDefinition.View(from: decoder))
+                    case "app.bsky.embed.gallery#view":
+                        self = .embedGalleryView(try AppBskyLexicon.Embed.GalleryDefinition.View(from: decoder))
                     default:
                         let singleValueDecodingContainer = try decoder.singleValueContainer()
                         let dictionary = try Self.decodeDictionary(from: singleValueDecodingContainer, decoder: decoder)
@@ -182,6 +187,8 @@ extension AppBskyLexicon.Feed {
                     case .embedRecordView(let value):
                         try container.encode(value)
                     case .embedRecordWithMediaView(let value):
+                        try container.encode(value)
+                    case .embedGalleryView(let value):
                         try container.encode(value)
                     default:
                         break


### PR DESCRIPTION
## Description
This adds support for the new Gallery lexicon introduced today by Bluesky. Thanks for all the notice, guys. 🙃

Bluesky posted about it here:
https://bsky.app/profile/did:plc:z72i7hdynmk6r22z27h6tvur/post/3mnslrkd6ok2g

The implementation is based on the Lexicon documented here:
https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/gallery.json

It's pretty straight-forward, so I hope it's not too much of an imposition to accept!

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

