### PR TITLE
Implement full support for creating `app.bsky.embed.gallery` structs

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
@@ -26,7 +26,7 @@ extension AppBskyLexicon.Embed {
         /// The identifier of the lexicon.
         ///
         /// - Warning: The value must not change.
-        public let type: String = "app.bsky.embed.gallery"
+        public static let type: String = "app.bsky.embed.gallery"
 
         /// The items in the gallery
         ///
@@ -46,7 +46,7 @@ extension AppBskyLexicon.Embed {
 
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(self.type, forKey: CodingKeys.type)
+            try container.encode(Self.type, forKey: CodingKeys.type)
             try container.truncatedEncodeIfPresent(self.items, forKey: CodingKeys.items, upToArrayLength: 10)
         }
 

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
@@ -42,6 +42,59 @@ extension AppBskyLexicon.Embed {
         }
 
         // Enums
+        /// A data model for an external definition.
+        ///
+        /// - SeeAlso: This is based on the [`app.bsky.embed.images`][github] lexicon.
+        ///
+        /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/gallery.json
+        public struct Image: Sendable, Codable, Equatable, Hashable {
+
+            /// The identifier of the lexicon.
+            ///
+            /// - Warning: The value must not change.
+            public let type: String = "app.bsky.embed.gallery#image"
+
+            /// The image that needs to be uploaded.
+            ///
+            /// - Warning: The image size can't be higher than 2 MB. Failure to do so will result
+            /// in the image failing to upload.
+            public let imageBlob: ComAtprotoLexicon.Repository.UploadBlobOutput
+
+            /// The alternative text for the image.
+            ///
+            /// - Note: From the AT Protocol specification: "Alt text description of the image,
+            /// for accessibility."
+            public let altText: String
+
+            /// The aspect ratio of the image. Optional.
+            public let aspectRatio: AspectRatioDefinition?
+
+            public init(imageBlob: ComAtprotoLexicon.Repository.UploadBlobOutput, altText: String, aspectRatio: AspectRatioDefinition?) {
+                self.imageBlob = imageBlob
+                self.altText = altText
+                self.aspectRatio = aspectRatio
+            }
+
+            public init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                self.imageBlob = try container.decode(ComAtprotoLexicon.Repository.UploadBlobOutput.self, forKey: CodingKeys.imageBlob)
+                self.altText = try container.decode(String.self, forKey: CodingKeys.altText)
+                self.aspectRatio = try container.decodeIfPresent(AppBskyLexicon.Embed.AspectRatioDefinition.self, forKey: CodingKeys.aspectRatio)
+            }
+            
+            public func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(self.imageBlob, forKey: CodingKeys.imageBlob)
+                try container.encode(self.altText, forKey: CodingKeys.altText)
+                try container.encodeIfPresent(self.aspectRatio, forKey: CodingKeys.aspectRatio)
+            }
+            
+            enum CodingKeys: String, CodingKey {
+                case imageBlob = "image"
+                case altText = "alt"
+                case aspectRatio
+            }
+        }
         /// A data model for the embed gallery view definition.
         ///
         /// - SeeAlso: This is based on the [`app.bsky.embed.gallery`][github] lexicon.

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
@@ -107,7 +107,7 @@ extension AppBskyLexicon.Embed {
             /// The identifier of the lexicon.
             ///
             /// - Warning: The value must not change.
-            public let type: String = "app.bsky.embed.gallery#image"
+            public static let type: String = "app.bsky.embed.gallery#image"
 
             /// The image that needs to be uploaded.
             ///
@@ -139,12 +139,14 @@ extension AppBskyLexicon.Embed {
             
             public func encode(to encoder: any Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
+                try container.encode(Self.type, forKey: CodingKeys.type)
                 try container.encode(self.imageBlob, forKey: CodingKeys.imageBlob)
                 try container.encode(self.altText, forKey: CodingKeys.altText)
                 try container.encodeIfPresent(self.aspectRatio, forKey: CodingKeys.aspectRatio)
             }
             
             enum CodingKeys: String, CodingKey {
+                case type = "$type"
                 case imageBlob = "image"
                 case altText = "alt"
                 case aspectRatio

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
@@ -162,7 +162,7 @@ extension AppBskyLexicon.Embed {
             /// The identifier of the lexicon.
             ///
             /// - Warning: The value must not change.
-            public let type: String = "app.bsky.embed.gallery#view"
+            public static let type: String = "app.bsky.embed.gallery#view"
 
             /// An array of images.
             public let items: [ViewImage]
@@ -180,7 +180,7 @@ extension AppBskyLexicon.Embed {
             public func encode(to encoder: any Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
 
-                try container.encode(self.type, forKey: .type)
+                try container.encode(Self.type, forKey: .type)
                 try container.encode(self.items, forKey: .items)
             }
 
@@ -200,7 +200,7 @@ extension AppBskyLexicon.Embed {
             /// The identifier of the lexicon.
             ///
             /// - Warning: The value must not change.
-            public let type: String = "app.bsky.embed.gallery#viewImage"
+            public static let type: String = "app.bsky.embed.gallery#viewImage"
 
             /// The URI of the image's thumbnail.
             ///
@@ -242,7 +242,7 @@ extension AppBskyLexicon.Embed {
             public func encode(to encoder: any Encoder) throws {
                 var container = encoder.container(keyedBy: CodingKeys.self)
 
-                try container.encode(self.type, forKey: .type)
+                try container.encode(Self.type, forKey: .type)
                 try container.encode(self.thumbnailImageURL, forKey: .thumbnailImageURL)
                 try container.encode(self.fullSizeImageURL, forKey: .fullSizeImageURL)
                 try container.encode(self.altText, forKey: .altText)

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
@@ -99,7 +99,7 @@ extension AppBskyLexicon.Embed {
         // Enums
         /// A data model for an external definition.
         ///
-        /// - SeeAlso: This is based on the [`app.bsky.embed.images`][github] lexicon.
+        /// - SeeAlso: This is based on the [`app.bsky.embed.gallery`][github] lexicon.
         ///
         /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/gallery.json
         public struct Image: Sendable, Codable, Equatable, Hashable {

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
@@ -28,17 +28,31 @@ extension AppBskyLexicon.Embed {
         /// - Warning: The value must not change.
         public let type: String = "app.bsky.embed.gallery"
 
-        public init() {}
+        /// The items in the gallery
+        ///
+        /// - Important: The schema-level maxLength of 20 is a future-proof ceiling. Clients should currently enforce a soft limit of 10 items in authoring UIs.
+        public let items: [ItemUnion]
+        
+        
+        public init(items: [ItemUnion]) {
+            self.items = items
+        }
 
-        public init(from decoder: any Decoder) throws {}
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            
+            self.items = try container.decode([ItemUnion].self, forKey: .items)
+        }
 
         public func encode(to encoder: any Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(self.type, forKey: CodingKeys.type)
+            try container.truncatedEncodeIfPresent(self.items, forKey: CodingKeys.items, upToArrayLength: 10)
         }
 
         enum CodingKeys: String, CodingKey {
             case type = "$type"
+            case items
         }
 
         // Unions

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGallery.swift
@@ -41,6 +41,47 @@ extension AppBskyLexicon.Embed {
             case type = "$type"
         }
 
+        // Unions
+        /// A specific gallery item
+        public enum ItemUnion: ATUnionProtocol, Equatable, Hashable {
+            
+            /// A gallery image.
+            case itemImage(AppBskyLexicon.Embed.GalleryDefinition.Image)
+            
+            // An unknown case.
+            case unknown(String, [String: CodableValue])
+            
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let type = try container.decodeIfPresent(String.self, forKey: .type)
+                
+                switch type {
+                    case "app.bsky.embed.gallery#image":
+                        self = .itemImage(try AppBskyLexicon.Embed.GalleryDefinition.Image(from: decoder))
+                    default:
+                        let singleValueDecodingContainer = try decoder.singleValueContainer()
+                        let dictionary = try Self.decodeDictionary(from: singleValueDecodingContainer, decoder: decoder)
+
+                        self = .unknown(type ?? "unknown", dictionary)
+                }
+            }
+            
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                
+                switch self {
+                    case .itemImage(let value):
+                        try container.encode(value)
+                    default:
+                        break
+                }
+            }
+            
+            enum CodingKeys: String, CodingKey {
+                case type = "$type"
+            }
+        }
+        
         // Enums
         /// A data model for an external definition.
         ///


### PR DESCRIPTION
## Description
This PR adds the ability to initialize the `app.bsky.embed.gallery` lexicon by completing the gallery definition and providing an initializer implementation. Additionally, it adds the missing `app.bsky.embed.gallery#image` definition.

## Type of Change
- [X] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [X] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [X] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings or errors in the compiler or runtime.
- [X] My code is able to build and run on my machine.
