### PR TITLE
fix contentTypeValue in bookmark toggle methods

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyBookmarkCreateBookmarkMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyBookmarkCreateBookmarkMethod.swift
@@ -57,7 +57,7 @@ extension ATProtoKit {
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
-                contentTypeValue: nil,
+                contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyBookmarkDeleteBookmarkMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyBookmarkDeleteBookmarkMethod.swift
@@ -49,7 +49,7 @@ extension ATProtoKit {
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
-                contentTypeValue: nil,
+                contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
 


### PR DESCRIPTION
## Description
This PR addresses the issue described in issue #254, where `createBookmark()` and `deleteBookmark()` do not send the `Content-Type: application/json` header.
Please refer to the issue for details. As noted in the issue, this fix only involves modifying the arguments in the relevant lines of code.

## Linked Issues
#254

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
I'm sorry, but since I'm writing this while traveling, I don't have any screenshots ready.
I apologize.

## Additional Notes
There are no items to add to the document, so there is no checkbox for that.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
