### PR TITLE
fix: percent-encode `+` in setQueryItems so cursor pagination works

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,9 +40,9 @@ let package = Package(
 //            dependencies: ["VersionNumberPluginExec"]
 //        )
 
-//        .testTarget(
-//            name: "ATProtoKitTests",
-//            dependencies: ["ATProtoKit"]),
+        .testTarget(
+            name: "ATProtoKitTests",
+            dependencies: ["ATProtoKit"]),
     ]
 )
 

--- a/Sources/ATProtoKit/Utilities/APIClientService.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientService.swift
@@ -170,6 +170,9 @@ public struct APIClientService: Sendable {
 
         // Map out each URLQueryItem with the key ($0.0) and value ($0.1) of the item.
         components?.queryItems = queryItems.map { URLQueryItem(name: $0.0, value: $0.1) }
+        if let percentEncodedQuery = components?.percentEncodedQuery {
+            components?.percentEncodedQuery = percentEncodedQuery.replacingOccurrences(of: "+", with: "%2B")
+        }
 
         guard let finalURL = components?.url else {
             throw ATHTTPRequestError.failedToConstructURLWithParameters

--- a/Tests/ATProtoKitTests/ATProtoKitTests.swift
+++ b/Tests/ATProtoKitTests/ATProtoKitTests.swift
@@ -2,11 +2,27 @@ import XCTest
 @testable import ATProtoKit
 
 final class ATProtoKitTests: XCTestCase {
-    func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
+    func testSetQueryItemsPercentEncodesPlusSigns() throws {
+        let apiClientService = APIClientService(with: APIClientConfiguration())
+        let requestURL = try XCTUnwrap(URL(string: "https://example.com/xrpc/app.bsky.feed.getFeed"))
 
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+        let urlWithPlus = try apiClientService.setQueryItems(for: requestURL, with: [
+            ("cursor", "abc+def")
+        ])
+        XCTAssertEqual(urlWithPlus.absoluteString, "https://example.com/xrpc/app.bsky.feed.getFeed?cursor=abc%2Bdef")
+        XCTAssertFalse(urlWithPlus.absoluteString.contains("+"))
+
+        let urlWithoutPlus = try apiClientService.setQueryItems(for: requestURL, with: [
+            ("cursor", "abcdef")
+        ])
+        XCTAssertEqual(urlWithoutPlus.absoluteString, "https://example.com/xrpc/app.bsky.feed.getFeed?cursor=abcdef")
+        XCTAssertFalse(urlWithoutPlus.absoluteString.contains("+"))
+
+        let urlWithMultipleItems = try apiClientService.setQueryItems(for: requestURL, with: [
+            ("cursor", "abc+def"),
+            ("limit", "50")
+        ])
+        XCTAssertEqual(urlWithMultipleItems.absoluteString, "https://example.com/xrpc/app.bsky.feed.getFeed?cursor=abc%2Bdef&limit=50")
+        XCTAssertFalse(urlWithMultipleItems.absoluteString.contains("+"))
     }
 }


### PR DESCRIPTION
## Description
`APIClientService.setQueryItems(for:with:)` builds query strings with `URLComponents`/`URLQueryItem`, which leave a literal `+` unescaped in query values. Bluesky's HTTP servers apply `application/x-www-form-urlencoded` semantics and decode a bare `+` as a space, so a cursor that contains `+` (e.g. a base64 segment from a feed generator) gets corrupted when it is sent back. The decoded cursor no longer matches the one the AppView issued, which returns HTTP 502 and breaks cursor-based pagination.

This patch rewrites `percentEncodedQuery` after the query items are assigned, replacing any literal `+` with `%2B`. Existing escaping produced by `URLQueryItem` is preserved; only the bare `+` is encoded. The reporter verified with `curl` that the same cursor returns HTTP 200 when sent as `%2B` and HTTP 502 when sent as a bare `+`.

A narrowly scoped unit test is added covering a value with `+`, a value without `+`, and a mix of multiple query items. The package's test target was commented out in `Package.swift`, so it is re-enabled so the test is discovered and run by `swift test`.

A broader alternative would be to serialize the whole query as form-urlencoded; that is intentionally left out here to keep the change small and reversible, and is noted for your discretion.

## Linked Issues
#256

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
Not applicable.

## Additional Notes
`swift build` and `swift test` both pass locally (1 test executed, 0 failures). If you would prefer to keep the test target disabled, I am happy to drop the `Package.swift` change and the test.

## Credits
- GitHub: mvanhorn

Fixes #256
