### PR TITLE
Corrected the typo “app.bsky.graph.listBlock”

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/BlockRecord/CreateBlockRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/BlockRecord/CreateBlockRecord.swift
@@ -62,7 +62,7 @@ extension ATProtoBluesky {
                         listURI: listURI,
                         createdAt: Date()
                     )
-                    collection = "app.bsky.graph.listBlock"
+                    collection = "app.bsky.graph.listblock"
                 } catch {
                     throw error
                 }


### PR DESCRIPTION
## Description
This pull request addresses the issue reported in issue #257. It resolves an issue where the name of the lexicon in the `createBlockRecord` function was incorrect.
For more details, please refer to the relevant issue. As noted in the issue, this fix simply changes the literal in the relevant line of code.

## Linked Issues
#257

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
I'm sorry, but since I'm writing this while traveling, I don't have any screenshots ready.
I apologize.

## Additional Notes
There are no items to add to the document, so there is no checkbox for that.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
