### PR TITLE
Add a branch for the `text/vtt` case

### DIFF
--- a/Sources/ATProtoKit/Utilities/APIClientService.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientService.swift
@@ -427,6 +427,7 @@ public struct APIClientService: Sendable {
             case "webp": return "image/webp"
             case "mp4": return "video/mp4"
             case "mov": return "video/quicktime"
+            case "vtt": return "text/vtt"
             default: return "application/octet-stream"
         }
     }


### PR DESCRIPTION
## Description
This pull request addresses the issue reported in issue #255. This change adds a branch to the `mimeType` function to handle cases where the input is a caption.
For more details, please refer to the relevant issue. As noted in the issue, this fix simply adds a `case` statement to the `switch` block in the relevant line of code.

## Linked Issues
#255

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
I'm sorry, but since I'm writing this while traveling, I don't have any screenshots ready.
I apologize.

## Additional Notes
There are no items to add to the document, so there is no checkbox for that.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
