### PR TITLE
Corrections to the `contentTypeValue` and `andMethod` arguments in the `muteThread` and `unmuteThread` functions

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphMuteThreadMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphMuteThreadMethod.swift
@@ -47,9 +47,9 @@ extension ATProtoKit {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
-                contentTypeValue: nil,
+                contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
 

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphUnmuteThreadMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphUnmuteThreadMethod.swift
@@ -46,9 +46,9 @@ extension ATProtoKit {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
-                contentTypeValue: nil,
+                contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)"
             )
 


### PR DESCRIPTION
## Description
This pull request addresses the issue reported in Issue #258. This change updates the request to send `Content-Type: application/json` and changes the method from `GET` to `POST`.
For more details, please refer to the relevant issue. As noted in the issue, this fix involves modifying the arguments in the relevant line of code.

## Linked Issues
#258

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
I'm sorry, but since I'm writing this while traveling, I don't have any screenshots ready.
I apologize.

## Additional Notes
There are no items to add to the document, so there is no checkbox for that.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
