### PR TITLE
[Bug Fix] Fix threadgate not allowing no one can reply ruleset

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ThreadgateRecord/CreateThreadgateRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ThreadgateRecord/CreateThreadgateRecord.swift
@@ -89,7 +89,7 @@ extension ATProtoBluesky {
             }
         }
 
-        let finalThreadgateAllowArray = threadgateAllowArray.isEmpty ? nil : threadgateAllowArray
+		let finalThreadgateAllowArray = replyControls == nil ? nil : threadgateAllowArray
 
         let threadgateRecord = AppBskyLexicon.Feed.ThreadgateRecord(
             postURI: postURI,

--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ThreadgateRecord/UpdateThreadgateRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ThreadgateRecord/UpdateThreadgateRecord.swift
@@ -54,7 +54,7 @@ extension ATProtoBluesky {
             }
         }
 
-        let finalThreadgateAllowArray = threadgateAllowArray.isEmpty ? nil : threadgateAllowArray
+		let finalThreadgateAllowArray = replyControls == nil ? nil : threadgateAllowArray
 
         let threadgateRecord = AppBskyLexicon.Feed.ThreadgateRecord(
             postURI: postURI,


### PR DESCRIPTION
## Description
Creating or updating a threadgate record (createThreadgateRecord and updateThreadgateRecord functions) took an array of ThreadgateAllowRule in the replyControls argument. Passing nil as that argument means everyone can reply and passing an empty array means no one can reply. But the function checked if the array is empty and set it to nil if it is, thus not allowing creating a threadgate where no one can reply. This PR addresses this issue by instead checking if the input argument is nil and then passing nil, otherwise passing the empty array.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Testing
After these changes passing nil still allows everyone to reply, and passing an empty array now correctly allows no one to reply.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Kernel]
- GitHub: [KernelFox0]
- Bluesky: [kernelfox.com.de]
