### PR TITLE
Fix draft record path from app.bsky.drafts.~ to app.bsky.draft.~

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftDefs.swift
@@ -19,7 +19,7 @@ extension AppBskyLexicon.Draft {
         /// The identifier of the lexicon.
         ///
         /// - Warning: The value must not change.
-        public static let type: String = "app.bsky.drafts.defs#draftWithId"
+        public static let type: String = "app.bsky.draft.defs#draftWithId"
         
         /// A TID to be used as a draft identifier.
         public let tid: String
@@ -64,7 +64,7 @@ extension AppBskyLexicon.Draft {
         /// The identifier of the lexicon.
         ///
         /// - Warning: The value must not change.
-        public static let type: String = "app.bsky.drafts.defs#draft"
+        public static let type: String = "app.bsky.draft.defs#draft"
         
         /// UUIDv4 identifier of the device that created this draft. Optional.
         ///
@@ -249,7 +249,7 @@ extension AppBskyLexicon.Draft {
         /// The identifier of the lexicon.
         ///
         /// - Warning: The value must not change.
-        public static let type: String = "app.bsky.drafts.defs#draftPost"
+        public static let type: String = "app.bsky.draft.defs#draftPost"
         
         /// The primary post content.
         ///
@@ -381,7 +381,7 @@ extension AppBskyLexicon.Draft {
         /// The identifier of the lexicon.
         ///
         /// - Warning: The value must not change.
-        public static let type: String = "app.bsky.drafts.defs#draftView"
+        public static let type: String = "app.bsky.draft.defs#draftView"
         
         /// A TID to be used as a draft identifier.
         public let tid: String
@@ -588,7 +588,7 @@ extension AppBskyLexicon.Draft {
         /// The identifier of the lexicon.
         ///
         /// - Warning: The value must not change.
-        public static let type: String = "app.bsky.drafts.defs#draftEmbedImage"
+        public static let type: String = "app.bsky.draft.defs#draftEmbedImage"
         
         /// A reference to the image, local to the drafting device
         public let localRef: DraftEmbedLocalReferenceDefinition


### PR DESCRIPTION
## Description
This pull request addresses the issue reported in Issue #271. With this change, the path will be updated from `app.bsky.drafts.~` to `app.bsky.draft.~`, which is the correct value.

## Linked Issues
#271

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
This change only corrects a constant value, so there are no screenshots to provide.

## Additional Notes
No documentation changes were required for this fix.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
