### PR TITLE
The AllIncoming enum was missing its raw value type declaration

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Actor/ChatBskyActorDeclaration.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Actor/ChatBskyActorDeclaration.swift
@@ -52,7 +52,7 @@ extension ChatBskyLexicon.Actor {
 
         // Enums
         /// A rule that states who can message the user account.
-        public enum AllIncoming: Sendable, Codable {
+        public enum AllIncoming: String, Sendable, Codable {
 
             /// Indicates that anyone can message the user account.
             case all


### PR DESCRIPTION
## Description
This pull request addresses the issue reported in Issue #273. The affected enum was missing its raw value type declaration. This change adds String as the raw value type, ensuring that the generated values match the AT Protocol specification and can be correctly encoded and decoded.

## Linked Issues
#273

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
This change only adds a raw value type declaration and does not affect the user interface.

## Additional Notes
No documentation changes were required for this fix.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
