### PR TITLE
feat: Add Starter Pack CRUD wrapper methods to ATProtoBluesky

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/StarterPackRecord/AddFeedToStarterPackRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/StarterPackRecord/AddFeedToStarterPackRecord.swift
@@ -1,0 +1,73 @@
+//
+//  AddFeedToStarterPackRecord.swift
+//
+//
+//  Created by Christopher Jr Riley on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoBluesky {
+
+    /// A convenience method to add a feed to an existing starter pack record in Bluesky.
+    ///
+    /// This reads the current starter pack record, appends the feed, and updates the record.
+    /// A starter pack can reference at most three feeds; adding a feed beyond that limit, or one
+    /// that is already present, throws an ``ATProtoBlueskyError``.
+    ///
+    /// ```swift
+    /// do {
+    ///     let starterPackResult = try await atProtoBluesky.addFeedToStarterPackRecord(
+    ///         starterPackURI: "at://did:plc:example/app.bsky.graph.starterpack/3kabcde",
+    ///         feedURI: "at://did:plc:example/app.bsky.feed.generator/whats-hot"
+    ///     )
+    ///
+    ///     print(starterPackResult)
+    /// } catch {
+    ///     throw error
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - starterPackURI: The URI of the starter pack.
+    ///   - feedURI: The URI of the feed to add.
+    /// - Returns: A strong reference, which contains the updated record's URI and CID hash.
+    ///
+    /// - Throws: An ``ATProtoBlueskyError`` if the record could not be found, the feed is already
+    /// present, or the starter pack already references three feeds.
+    public func addFeedToStarterPackRecord(
+        starterPackURI: String,
+        feedURI: String
+    ) async throws -> ComAtprotoLexicon.Repository.StrongReference {
+        let uri = try ATProtoTools().parseURI(starterPackURI)
+
+        guard let record = try await atProtoKitInstance.getRepositoryRecord(
+            from: uri.repository,
+            collection: uri.collection,
+            recordKey: uri.recordKey
+        ).value,
+              let starterPack = record.getRecord(ofType: AppBskyLexicon.Graph.StarterpackRecord.self) else {
+            throw ATProtoBlueskyError.recordNotFound(message: "Starter pack record (\(starterPackURI)) not found.")
+        }
+
+        var feeds = starterPack.feeds?.map { $0.uri } ?? []
+
+        if feeds.contains(feedURI) {
+            throw ATProtoBlueskyError.tooManyFeeds(message: "The feed (\(feedURI)) is already in the starter pack.")
+        }
+
+        if feeds.count >= 3 {
+            throw ATProtoBlueskyError.tooManyFeeds(message: "A starter pack can contain at most three feeds.")
+        }
+
+        feeds.append(feedURI)
+
+        return try await updateStarterPackRecord(
+            starterPackURI: starterPackURI,
+            feeds: feeds
+        )
+    }
+}

--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/StarterPackRecord/CreateStarterPackRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/StarterPackRecord/CreateStarterPackRecord.swift
@@ -1,0 +1,124 @@
+//
+//  CreateStarterPackRecord.swift
+//
+//
+//  Created by Christopher Jr Riley on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoBluesky {
+
+    /// A convenience method to create a starter pack record to the user account in Bluesky.
+    ///
+    /// This can be used instead of creating your own method if you wish not to do so.
+    ///
+    /// A starter pack groups a reference list of user accounts together with up to three feeds,
+    /// giving new users a curated starting point. The `listURI` must point to an existing
+    /// reference list record (created via ``createListRecord(named:ofType:description:listAvatarImage:labels:creationDate:recordKey:shouldValidate:swapCommit:)``
+    /// with a type of ``ListType/reference``).
+    ///
+    /// ```swift
+    /// do {
+    ///     let starterPackResult = try await atProtoBluesky.createStarterPackRecord(
+    ///         named: "Book Authors",
+    ///         listURI: "at://did:plc:example/app.bsky.graph.list/3kabcde",
+    ///         feeds: ["at://did:plc:example/app.bsky.feed.generator/whats-hot"]
+    ///     )
+    ///
+    ///     print(starterPackResult)
+    /// } catch {
+    ///     throw error
+    /// }
+    /// ```
+    ///
+    /// - Note: Names can be up to 50 characters long. \
+    /// \
+    /// Descriptions can be up to 300 characters long. \
+    /// \
+    /// A starter pack can reference up to three feeds.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the starter pack.
+    ///   - description: The starter pack's description. Optional. Defaults to `nil`.
+    ///   - listURI: The URI of the reference list the starter pack is built around.
+    ///   - feeds: An array of feed URIs to include in the starter pack. Optional.
+    ///   Defaults to an empty array.
+    ///   - creationDate: The date of the starter pack record. Defaults to `Date.now`.
+    ///   - recordKey: The record key of the collection. Optional. Defaults to `nil`.
+    ///   - shouldValidate: Indicates whether the record should be validated. Optional.
+    ///   Defaults to `true`.
+    ///   - swapCommit: Swaps out an operation based on the CID. Optional. Defaults to `nil`.
+    /// - Returns: A strong reference, which contains the newly-created record's URI and CID hash.
+    ///
+    /// - Throws: An ``ATProtoBlueskyError`` if more than three feeds are provided, or an error
+    /// related to the AT Protocol if the record could not be created.
+    public func createStarterPackRecord(
+        named name: String,
+        description: String? = nil,
+        listURI: String,
+        feeds: [String] = [],
+        creationDate: Date = Date(),
+        recordKey: String? = nil,
+        shouldValidate: Bool? = true,
+        swapCommit: String? = nil
+    ) async throws -> ComAtprotoLexicon.Repository.StrongReference {
+        guard let session = try await atProtoKitInstance.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        // feeds
+        // A starter pack can reference at most three feeds.
+        if feeds.count > 3 {
+            throw ATProtoBlueskyError.tooManyFeeds(message: "A starter pack can contain at most three feeds.")
+        }
+
+        // name
+        // Truncate the number of characters to 50.
+        let nameText = name.truncated(toLength: 50)
+
+        // description and descriptionFacets
+        var descriptionText: String? = nil
+        var descriptionFacets: [AppBskyLexicon.RichText.Facet]? = nil
+
+        if let description = description {
+            // Truncate the number of characters to 300.
+            let truncatedDescriptionText = description.truncated(toLength: 300)
+            descriptionText = truncatedDescriptionText
+
+            let facets = await ATFacetParser.parseFacets(from: truncatedDescriptionText, pdsURL: session.pdsURL ?? "https://bsky.social")
+            descriptionFacets = facets
+        }
+
+        let feedItems = feeds.map { AppBskyLexicon.Graph.StarterpackRecord.FeedItem(uri: $0) }
+
+        let starterPackRecord = AppBskyLexicon.Graph.StarterpackRecord(
+            name: nameText,
+            description: descriptionText,
+            descriptionFacets: descriptionFacets,
+            listURI: listURI,
+            feeds: feedItems,
+            createdAt: creationDate
+        )
+
+        do {
+            let record = try await atProtoKitInstance.createRecord(
+                repositoryDID: session.sessionDID,
+                collection: "app.bsky.graph.starterpack",
+                recordKey: recordKey ?? nil,
+                shouldValidate: shouldValidate,
+                record: UnknownType.record(starterPackRecord),
+                swapCommit: swapCommit ?? nil
+            )
+
+            try await Task.sleep(nanoseconds: 500_000_000)
+
+            return record
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/StarterPackRecord/RemoveFeedFromStarterPackRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/StarterPackRecord/RemoveFeedFromStarterPackRecord.swift
@@ -1,0 +1,68 @@
+//
+//  RemoveFeedFromStarterPackRecord.swift
+//
+//
+//  Created by Christopher Jr Riley on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoBluesky {
+
+    /// A convenience method to remove a feed from an existing starter pack record in Bluesky.
+    ///
+    /// This reads the current starter pack record, removes the feed, and updates the record.
+    /// If the feed is not present in the starter pack, an ``ATProtoBlueskyError`` is thrown.
+    ///
+    /// ```swift
+    /// do {
+    ///     let starterPackResult = try await atProtoBluesky.removeFeedFromStarterPackRecord(
+    ///         starterPackURI: "at://did:plc:example/app.bsky.graph.starterpack/3kabcde",
+    ///         feedURI: "at://did:plc:example/app.bsky.feed.generator/whats-hot"
+    ///     )
+    ///
+    ///     print(starterPackResult)
+    /// } catch {
+    ///     throw error
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - starterPackURI: The URI of the starter pack.
+    ///   - feedURI: The URI of the feed to remove.
+    /// - Returns: A strong reference, which contains the updated record's URI and CID hash.
+    ///
+    /// - Throws: An ``ATProtoBlueskyError`` if the record could not be found or the feed is not
+    /// present in the starter pack.
+    public func removeFeedFromStarterPackRecord(
+        starterPackURI: String,
+        feedURI: String
+    ) async throws -> ComAtprotoLexicon.Repository.StrongReference {
+        let uri = try ATProtoTools().parseURI(starterPackURI)
+
+        guard let record = try await atProtoKitInstance.getRepositoryRecord(
+            from: uri.repository,
+            collection: uri.collection,
+            recordKey: uri.recordKey
+        ).value,
+              let starterPack = record.getRecord(ofType: AppBskyLexicon.Graph.StarterpackRecord.self) else {
+            throw ATProtoBlueskyError.recordNotFound(message: "Starter pack record (\(starterPackURI)) not found.")
+        }
+
+        let feeds = starterPack.feeds?.map { $0.uri } ?? []
+
+        guard feeds.contains(feedURI) else {
+            throw ATProtoBlueskyError.recordNotFound(message: "The feed (\(feedURI)) is not in the starter pack.")
+        }
+
+        let updatedFeeds = feeds.filter { $0 != feedURI }
+
+        return try await updateStarterPackRecord(
+            starterPackURI: starterPackURI,
+            feeds: updatedFeeds
+        )
+    }
+}

--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/StarterPackRecord/UpdateStarterPackRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/StarterPackRecord/UpdateStarterPackRecord.swift
@@ -1,0 +1,131 @@
+//
+//  UpdateStarterPackRecord.swift
+//
+//
+//  Created by Christopher Jr Riley on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoBluesky {
+
+    /// A convenience method to update a starter pack record in the user account in Bluesky.
+    ///
+    /// This can be used instead of creating your own method if you wish not to do so.
+    ///
+    /// The current record is fetched first, and any argument left as `nil` keeps the existing
+    /// value, so you only need to supply the fields you want to change.
+    ///
+    /// ```swift
+    /// do {
+    ///     let starterPackResult = try await atProtoBluesky.updateStarterPackRecord(
+    ///         starterPackURI: "at://did:plc:example/app.bsky.graph.starterpack/3kabcde",
+    ///         name: "Updated Name"
+    ///     )
+    ///
+    ///     print(starterPackResult)
+    /// } catch {
+    ///     throw error
+    /// }
+    /// ```
+    ///
+    /// - Note: Names can be up to 50 characters long. \
+    /// \
+    /// Descriptions can be up to 300 characters long. \
+    /// \
+    /// A starter pack can reference up to three feeds.
+    ///
+    /// - Parameters:
+    ///   - starterPackURI: The URI of the starter pack.
+    ///   - name: The new name of the starter pack. Optional. Defaults to `nil` (unchanged).
+    ///   - description: The new description of the starter pack. Optional. Defaults to `nil`
+    ///   (unchanged).
+    ///   - descriptionFacets: The new facets within the description. Optional. Defaults to `nil`
+    ///   (unchanged).
+    ///   - listURI: The new URI of the reference list. Optional. Defaults to `nil` (unchanged).
+    ///   - feeds: The new array of feed URIs. Optional. Defaults to `nil` (unchanged).
+    /// - Returns: A strong reference, which contains the updated record's URI and CID hash.
+    ///
+    /// - Throws: An ``ATProtoBlueskyError`` if the record could not be found or more than three
+    /// feeds are provided, or an error related to the AT Protocol if the record could not be
+    /// updated.
+    public func updateStarterPackRecord(
+        starterPackURI: String,
+        name: String? = nil,
+        description: String? = nil,
+        descriptionFacets: [AppBskyLexicon.RichText.Facet]? = nil,
+        listURI: String? = nil,
+        feeds: [String]? = nil
+    ) async throws -> ComAtprotoLexicon.Repository.StrongReference {
+        guard let session = try await atProtoKitInstance.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        if let feeds = feeds, feeds.count > 3 {
+            throw ATProtoBlueskyError.tooManyFeeds(message: "A starter pack can contain at most three feeds.")
+        }
+
+        let uri = try ATProtoTools().parseURI(starterPackURI)
+
+        guard let record = try await atProtoKitInstance.getRepositoryRecord(
+            from: uri.repository,
+            collection: uri.collection,
+            recordKey: uri.recordKey
+        ).value,
+              let starterPack = record.getRecord(ofType: AppBskyLexicon.Graph.StarterpackRecord.self) else {
+            throw ATProtoBlueskyError.recordNotFound(message: "Starter pack record (\(starterPackURI)) not found.")
+        }
+
+        // Carry over the current values, overriding only the fields that were supplied.
+        let newName = name.map { $0.truncated(toLength: 50) } ?? starterPack.name
+
+        let newDescription: String?
+        let newDescriptionFacets: [AppBskyLexicon.RichText.Facet]?
+
+        if let description = description {
+            let truncatedDescription = description.truncated(toLength: 300)
+            newDescription = truncatedDescription
+
+            if let descriptionFacets = descriptionFacets {
+                newDescriptionFacets = descriptionFacets
+            } else {
+                newDescriptionFacets = await ATFacetParser.parseFacets(from: truncatedDescription, pdsURL: session.pdsURL ?? "https://bsky.social")
+            }
+        } else {
+            newDescription = starterPack.description
+            newDescriptionFacets = descriptionFacets ?? starterPack.descriptionFacets
+        }
+
+        let newListURI = listURI ?? starterPack.listURI
+
+        let newFeeds: [AppBskyLexicon.Graph.StarterpackRecord.FeedItem]
+        if let feeds = feeds {
+            newFeeds = feeds.map { AppBskyLexicon.Graph.StarterpackRecord.FeedItem(uri: $0) }
+        } else {
+            newFeeds = starterPack.feeds ?? []
+        }
+
+        let starterPackRecord = AppBskyLexicon.Graph.StarterpackRecord(
+            name: newName,
+            description: newDescription,
+            descriptionFacets: newDescriptionFacets,
+            listURI: newListURI,
+            feeds: newFeeds,
+            createdAt: starterPack.createdAt
+        )
+
+        do {
+            return try await atProtoKitInstance.putRecord(
+                repository: session.sessionDID,
+                collection: "app.bsky.graph.starterpack",
+                recordKey: uri.recordKey,
+                record: UnknownType.record(starterPackRecord)
+            )
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/ATProtoKit.docc/Extensions/ATProtoBluesky/ATProtoBluesky.md
+++ b/Sources/ATProtoKit/ATProtoKit.docc/Extensions/ATProtoBluesky/ATProtoBluesky.md
@@ -55,7 +55,13 @@
 
 - ``createStatusRecord(_:embed:durationMinutes:shouldValidate:)``
 
-<!--### Starter Packs-->
+### Starter Packs
+
+- ``createStarterPackRecord(named:description:listURI:feeds:creationDate:recordKey:shouldValidate:swapCommit:)``
+- ``updateStarterPackRecord(starterPackURI:name:description:descriptionFacets:listURI:feeds:)``
+
+- ``addFeedToStarterPackRecord(starterPackURI:feedURI:)``
+- ``removeFeedFromStarterPackRecord(starterPackURI:feedURI:)``
 
 <!--### Feed Generators-->
 

--- a/Sources/ATProtoKit/Errors/ATProtoError.swift
+++ b/Sources/ATProtoKit/Errors/ATProtoError.swift
@@ -108,6 +108,11 @@ extension ATProtoBluesky {
         ///
         /// - Parameter message: The message of the error.
         case emptyReplaceArray(message: String)
+
+        /// Too many feeds were provided for a starter pack.
+        ///
+        /// - Parameter message: The message of the error.
+        case tooManyFeeds(message: String)
     }
 
     /// An error type specifically related to Bluesky (either before or after interacting with

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Graph/AppBskyGraphStarterpack.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Graph/AppBskyGraphStarterpack.swift
@@ -76,7 +76,7 @@ extension AppBskyLexicon.Graph {
             var container = encoder.container(keyedBy: CodingKeys.self)
 
             try container.truncatedEncode(self.name, forKey: .name, upToCharacterLength: 50)
-            try container.truncatedEncodeIfPresent(self.name, forKey: .name, upToCharacterLength: 300)
+            try container.truncatedEncodeIfPresent(self.description, forKey: .description, upToCharacterLength: 300)
             try container.encodeIfPresent(self.descriptionFacets, forKey: .descriptionFacets)
             try container.encode(self.listURI, forKey: .listURI)
             try container.truncatedEncodeIfPresent(self.feeds, forKey: .feeds, upToArrayLength: 3)
@@ -84,7 +84,7 @@ extension AppBskyLexicon.Graph {
         }
 
         enum CodingKeys: String, CodingKey {
-            case type = "Stype"
+            case type = "$type"
             case name
             case description
             case descriptionFacets


### PR DESCRIPTION
## Description
Adds convenience write-side wrappers for `app.bsky.graph.starterpack` records to `ATProtoBluesky`, mirroring the existing `ListRecord` wrappers. Four new public methods, each in its own file under a new `StarterPackRecord/` directory:

- `createStarterPackRecord(named:description:listURI:feeds:creationDate:recordKey:shouldValidate:swapCommit:)`
- `updateStarterPackRecord(starterPackURI:name:description:descriptionFacets:listURI:feeds:)` (fetch-then-put; nil arguments keep existing values)
- `addFeedToStarterPackRecord(starterPackURI:feedURI:)`
- `removeFeedFromStarterPackRecord(starterPackURI:feedURI:)`

Per your guidance on the issue, no dedicated `deleteStarterPackRecord` is added; the generic `deleteRecord()` already covers deletion.

`ATProtoBluesky` already has typed wrappers for posts, lists, blocks, threadgates, and profiles, plus the read-side starter pack queries and the `StarterpackRecord` model, but no way to create or update a starter pack without dropping down to raw `createRecord` / `putRecord` calls with hand-built JSON. These wrappers encapsulate AT URI parsing, the lexicon constraints (name up to 50 chars, description up to 300, feeds up to 3), and the fetch-then-put plumbing, the same way `createListRecord` / `updateListRecord` already do. The add/remove feed helpers read the current record, mutate the `feeds` array (enforcing the three-feed maximum and rejecting duplicates or absent feeds), and route through the update path. A `tooManyFeeds` case was added to `ATProtoBlueskyError`, and the methods are surfaced in the `ATProtoBluesky` DocC curation under a new Starter Packs section.

While wiring this up I also fixed two encoding bugs in the existing `StarterpackRecord` model that would otherwise make these wrappers write invalid records: the encoder wrote `name` twice and never encoded `description` (so the description was silently dropped on every write), and the `$type` discriminator key was misspelled as `Stype`.

## Linked Issues
Refs #267

## Type of Change
- [x] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
Not applicable.

## Additional Notes
The model encoding fix was verified against the official `app.bsky.graph.starterpack` lexicon (`$type`, `name`, `description`, `list`, `feeds`). `swift build` passes cleanly. The new methods follow the `CreateListRecord` / `UpdateListRecord` patterns one-to-one (session guard, truncation, facet parsing, and `createRecord` / `getRepositoryRecord` / `putRecord` calls).

## Credits
- Name: [Matt Van Horn]
- GitHub: [mvanhorn]
