### PR TITLE
Add draft management APIs and related type definitions

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftCreateDraftMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftCreateDraftMethod.swift
@@ -1,0 +1,68 @@
+//
+//  AppBskyDraftCreateDraftMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Creates a draft on the user's account.
+    ///
+    /// Drafts are server-synced post drafts stored in the user's private storage (stash).
+    ///
+    /// - Note: According to the AT Protocol specifications: "Inserts a draft using private storage (stash). An upper limit of drafts might be enforced.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.createDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/createDraft.json
+    ///
+    /// - Parameter draft: The draft to be created.
+    /// - Returns: The TID identifier assigned to the newly-created draft.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func createDraft(
+        _ draft: AppBskyLexicon.Draft.DraftDefinition
+    ) async throws -> AppBskyLexicon.Draft.CreateDraftOutput {
+        guard let session = try await self.getUserSession(),
+              let keychain = sessionConfiguration?.keychainProtocol else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        try await sessionConfiguration?.ensureValidToken()
+        let accessToken = try await keychain.retrieveAccessToken()
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.draft.createDraft") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = AppBskyLexicon.Draft.CreateDraftRequestBody(draft: draft)
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                authorizationValue: "Bearer \(accessToken)"
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: AppBskyLexicon.Draft.CreateDraftOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftDeleteDraftMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftDeleteDraftMethod.swift
@@ -1,0 +1,61 @@
+//
+//  AppBskyDraftDeleteDraftMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Deletes a draft on the user's account.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Deletes a draft by ID.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.deleteDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/deleteDraft.json
+    ///
+    /// - Parameter id: The TID identifier of the draft to delete.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func deleteDraft(id: String) async throws {
+        guard let session = try await self.getUserSession(),
+              let keychain = sessionConfiguration?.keychainProtocol else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        try await sessionConfiguration?.ensureValidToken()
+        let accessToken = try await keychain.retrieveAccessToken()
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.draft.deleteDraft") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = AppBskyLexicon.Draft.DeleteDraftRequestBody(id: id)
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                authorizationValue: "Bearer \(accessToken)"
+            )
+
+            _ = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody
+            )
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftGetDraftsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftGetDraftsMethod.swift
@@ -1,0 +1,86 @@
+//
+//  AppBskyDraftGetDraftsMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Retrieves the drafts for the authenticated user.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Gets views of user drafts.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.getDrafts`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/getDrafts.json
+    ///
+    /// - Parameters:
+    ///   - limit: The number of drafts to return. Optional. Defaults to `50`.
+    ///   Can only choose between 1 and 100.
+    ///   - cursor: The mark used to indicate the starting point for the next set
+    ///   of results. Optional.
+    /// - Returns: An array of drafts, with an optional cursor to expand the array.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getDrafts(
+        limit: Int? = 50,
+        cursor: String? = nil
+    ) async throws -> AppBskyLexicon.Draft.GetDraftsOutput {
+        guard let session = try await self.getUserSession(),
+              let keychain = sessionConfiguration?.keychainProtocol else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        try await sessionConfiguration?.ensureValidToken()
+        let accessToken = try await keychain.retrieveAccessToken()
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.draft.getDrafts") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        if let limit {
+            let finalLimit = max(1, min(limit, 100))
+            queryItems.append(("limit", "\(finalLimit)"))
+        }
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                authorizationValue: "Bearer \(accessToken)"
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: AppBskyLexicon.Draft.GetDraftsOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftUpdateDraftMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftUpdateDraftMethod.swift
@@ -1,0 +1,68 @@
+//
+//  AppBskyDraftUpdateDraftMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Updates an existing draft on the user's account.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Updates a draft using private storage (stash). If the draft ID points to a non-existing ID, the update will be silently ignored. This is done because updates don't enforce draft limit, so it accepts all writes, but will ignore invalid ones.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.updateDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/updateDraft.json
+    ///
+    /// - Parameters:
+    ///   - id: The TID identifier of the draft to update.
+    ///   - draft: The new contents of the draft.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func updateDraft(
+        id: String,
+        with draft: AppBskyLexicon.Draft.DraftDefinition
+    ) async throws {
+        guard let session = try await self.getUserSession(),
+              let keychain = sessionConfiguration?.keychainProtocol else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        try await sessionConfiguration?.ensureValidToken()
+        let accessToken = try await keychain.retrieveAccessToken()
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.draft.updateDraft") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = AppBskyLexicon.Draft.UpdateDraftRequestBody(
+            draft: AppBskyLexicon.Draft.DraftWithIdDefinition(tid: id, draft: draft)
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                authorizationValue: "Bearer \(accessToken)"
+            )
+
+            _ = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody
+            )
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/ATProtoKit.swift
+++ b/Sources/ATProtoKit/ATProtoKit.swift
@@ -193,7 +193,8 @@ public final class ATProtoKit: Sendable, ATProtoKitConfiguration, ATRecordConfig
             with: finalConfiguration
         )
         
-        if canUseBlueskyRecords && !(ATRecordTypeRegistry.areBlueskyRecordsRegistered) {
+        let areBlueskyRecordsRegistered = await ATRecordTypeRegistry.areBlueskyRecordsRegistered
+        if canUseBlueskyRecords && !areBlueskyRecordsRegistered {
             _ = await ATRecordTypeRegistry.shared.register(blueskyLexiconTypes: recordLexicons)
         }
     }

--- a/Sources/ATProtoKit/ATProtoKit.swift
+++ b/Sources/ATProtoKit/ATProtoKit.swift
@@ -129,13 +129,23 @@ public final class ATProtoKit: Sendable, ATProtoKitConfiguration, ATRecordConfig
     /// An array of record lexicon structs created by Bluesky.
     ///
     /// If `canUseBlueskyRecords` is set to `false`, these will not be used.
-    public let recordLexicons: [any ATRecordProtocol.Type] = [
-        AppBskyLexicon.Actor.ProfileRecord.self, AppBskyLexicon.Actor.StatusRecord.self, AppBskyLexicon.Feed.GeneratorRecord.self,
-        AppBskyLexicon.Feed.LikeRecord.self, AppBskyLexicon.Feed.PostRecord.self, AppBskyLexicon.Feed.PostgateRecord.self,
-        AppBskyLexicon.Feed.RepostRecord.self, AppBskyLexicon.Feed.ThreadgateRecord.self, AppBskyLexicon.Graph.BlockRecord.self,
-        AppBskyLexicon.Graph.FollowRecord.self, AppBskyLexicon.Graph.ListRecord.self, AppBskyLexicon.Graph.ListBlockRecord.self,
-        AppBskyLexicon.Graph.ListItemRecord.self, AppBskyLexicon.Graph.StarterpackRecord.self, AppBskyLexicon.Labeler.ServiceRecord.self,
-        ChatBskyLexicon.Actor.DeclarationRecord.self
+    public let recordLexicons: [ATRecordDecoder] = [
+        ATRecordDecoder(type: AppBskyLexicon.Actor.ProfileRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Actor.StatusRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Feed.GeneratorRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Feed.LikeRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Feed.PostRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Feed.PostgateRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Feed.RepostRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Feed.ThreadgateRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Graph.BlockRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Graph.FollowRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Graph.ListRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Graph.ListBlockRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Graph.ListItemRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Graph.StarterpackRecord.self),
+        ATRecordDecoder(type: AppBskyLexicon.Labeler.ServiceRecord.self),
+        ATRecordDecoder(type: ChatBskyLexicon.Actor.DeclarationRecord.self)
     ]
 
     /// Represents an object used for managing sessions.

--- a/Sources/ATProtoKit/ATProtoKit.swift
+++ b/Sources/ATProtoKit/ATProtoKit.swift
@@ -7,7 +7,7 @@ import Logging
 /// Defines a protocol for configurations in the `ATProtoKit` API library.
 ///
 /// `ATProtoKitConfiguration` defines the basic requirements for any class that may hold
-/// lexicon methods.  Any class that conforms to this protocol must be geared for sending API calls
+/// lexicon methods. Conforming classes must be geared for sending API calls
 /// to the AT Protocol. Creating a class that conforms to this is useful if you have additional
 /// lexicons specific to the service you're running.
 public protocol ATProtoKitConfiguration {

--- a/Sources/ATProtoKit/ATProtoKit.swift
+++ b/Sources/ATProtoKit/ATProtoKit.swift
@@ -192,7 +192,7 @@ public final class ATProtoKit: Sendable, ATProtoKitConfiguration, ATRecordConfig
         self.apiClientService = APIClientService(
             with: finalConfiguration
         )
-        
+
         let areBlueskyRecordsRegistered = await ATRecordTypeRegistry.areBlueskyRecordsRegistered
         if canUseBlueskyRecords && !areBlueskyRecordsRegistered {
             _ = await ATRecordTypeRegistry.shared.register(blueskyLexiconTypes: recordLexicons)

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftCreateDraft.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftCreateDraft.swift
@@ -1,0 +1,46 @@
+//
+//  AppBskyDraftCreateDraft.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Draft {
+
+    /// A request body model for creating a draft.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Inserts a draft using private storage (stash). An upper limit of drafts might be enforced.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.createDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/createDraft.json
+    public struct CreateDraftRequestBody: Sendable, Codable {
+
+        /// The draft to be created.
+        public let draft: AppBskyLexicon.Draft.DraftDefinition
+
+        public init(draft: AppBskyLexicon.Draft.DraftDefinition) {
+            self.draft = draft
+        }
+    }
+
+    /// An output model for creating a draft.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Creates a draft.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.createDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/createDraft.json
+    public struct CreateDraftOutput: Sendable, Codable {
+
+        /// The TID identifier assigned to the newly-created draft.
+        public let id: String
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftDeleteDraft.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftDeleteDraft.swift
@@ -1,0 +1,32 @@
+//
+//  AppBskyDraftDeleteDraft.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Draft {
+
+    /// A request body model for deleting a draft.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Deletes a draft by ID.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.deleteDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/deleteDraft.json
+    public struct DeleteDraftRequestBody: Sendable, Codable {
+
+        /// The TID identifier of the draft to delete.
+        public let id: String
+
+        public init(id: String) {
+            self.id = id
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftGetDrafts.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftGetDrafts.swift
@@ -1,0 +1,31 @@
+//
+//  AppBskyDraftGetDrafts.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Draft {
+
+    /// An output model for retrieving drafts.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Gets views of user drafts.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.getDrafts`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/getDrafts.json
+    public struct GetDraftsOutput: Sendable, Codable {
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+
+        /// An array of drafts.
+        public let drafts: [AppBskyLexicon.Draft.DraftViewDefinition]
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftUpdateDraft.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftUpdateDraft.swift
@@ -1,0 +1,32 @@
+//
+//  AppBskyDraftUpdateDraft.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Draft {
+
+    /// A request body model for updating an existing draft.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Updates a draft using private storage (stash). If the draft ID points to a non-existing ID, the update will be silently ignored. This is done because updates don't enforce draft limit, so it accepts all writes, but will ignore invalid ones.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.updateDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/updateDraft.json
+    public struct UpdateDraftRequestBody: Sendable, Codable {
+
+        /// The draft to be updated, containing its identifier.
+        public let draft: AppBskyLexicon.Draft.DraftWithIdDefinition
+
+        public init(draft: AppBskyLexicon.Draft.DraftWithIdDefinition) {
+            self.draft = draft
+        }
+    }
+}

--- a/Sources/ATProtoKit/Utilities/APIClientService.swift
+++ b/Sources/ATProtoKit/Utilities/APIClientService.swift
@@ -192,7 +192,11 @@ public struct APIClientService: Sendable {
     public func sendRequest<T: Decodable>(_ request: URLRequest, withEncodingBody body: (Encodable & Sendable)? = nil, decodeTo: T.Type) async throws -> T {
         let data = try await self.performRequest(request, withEncodingBody: body)
 
-        let decodedData = try JSONDecoder().decode(T.self, from: data)
+        let recordRegistry = await ATRecordTypeRegistry.recordRegistry
+        let decoder = JSONDecoder()
+        decoder.useRecordRegistrySnapshot(recordRegistry)
+
+        let decodedData = try decoder.decode(T.self, from: data)
         return decodedData
     }
 
@@ -237,7 +241,11 @@ public struct APIClientService: Sendable {
             throw URLError(.badServerResponse)
         }
 
-        let decodedData = try JSONDecoder().decode(T.self, from: responseData)
+        let recordRegistry = await ATRecordTypeRegistry.recordRegistry
+        let decoder = JSONDecoder()
+        decoder.useRecordRegistrySnapshot(recordRegistry)
+
+        let decodedData = try decoder.decode(T.self, from: responseData)
         return decodedData
     }
 

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -330,20 +330,6 @@ internal enum ATRecordDecodingUserInfoKey {
     static let recordRegistry = "dev.atprotokit.ATProtoKit.recordRegistry"
 }
 
-extension JSONDecoder {
-
-    /// Adds a record registry snapshot to the decoder's user info dictionary.
-    ///
-    /// - Parameter recordRegistry: The record decoder snapshot to use while decoding.
-    public func useRecordRegistrySnapshot(_ recordRegistry: [String: ATRecordDecoder]) {
-        guard let key = CodingUserInfoKey(rawValue: ATRecordDecodingUserInfoKey.recordRegistry) else {
-            return
-        }
-
-        self.userInfo[key] = recordRegistry
-    }
-}
-
 /// Handles decoding and encoding of records when their type is not known ahead of type.
 ///
 /// This supports either the instantiation of registered record types or fallback to a dictionary

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -319,6 +319,29 @@ public actor ATRecordTypeRegistry {
         // Clear the waiting list.
         continuations.removeAll()
     }
+Data
+
+Data
+
+/// A user info key used to pass record decoder snapshots into `Decoder` instances.
+internal enum ATRecordDecodingUserInfoKey {
+
+    /// The raw user info key value for record decoder snapshots.
+    static let recordRegistry = "dev.atprotokit.ATProtoKit.recordRegistry"
+}
+
+extension JSONDecoder {
+
+    /// Adds a record registry snapshot to the decoder's user info dictionary.
+    ///
+    /// - Parameter recordRegistry: The record decoder snapshot to use while decoding.
+    public func useRecordRegistrySnapshot(_ recordRegistry: [String: ATRecordDecoder]) {
+        guard let key = CodingUserInfoKey(rawValue: ATRecordDecodingUserInfoKey.recordRegistry) else {
+            return
+        }
+
+        self.userInfo[key] = recordRegistry
+    }
 }
 
 /// Handles decoding and encoding of records when their type is not known ahead of type.

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -98,6 +98,13 @@ public struct ATRecordDecoder: Sendable, Equatable, Hashable {
         }
     }
 
+    public static func == (lhs: ATRecordDecoder, rhs: ATRecordDecoder) -> Bool {
+        lhs.typeIdentifier == rhs.typeIdentifier
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(typeIdentifier)
+    }
 }
 
 /// A registry for all decodable record types in the AT Protocol.

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -71,7 +71,8 @@ public protocol ATRecordConfiguration {
     /// An array of record lexicon structs created by Bluesky.
     ///
     /// If `canUseBlueskyRecords` is set to `false`, these will not be used.
-    var recordLexicons: [any ATRecordProtocol.Type] { get }
+    var recordLexicons: [ATRecordDecoder] { get }
+
 }
 
 /// A decoder for a concrete ``ATRecordProtocol`` type.

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -74,6 +74,32 @@ public protocol ATRecordConfiguration {
     var recordLexicons: [any ATRecordProtocol.Type] { get }
 }
 
+/// A decoder for a concrete ``ATRecordProtocol`` type.
+///
+/// This value keeps the registry from storing protocol metatypes directly while still preserving
+/// the ability to decode records dynamically from their `$type` value.
+public struct ATRecordDecoder: Sendable, Equatable, Hashable {
+
+    /// The Namespaced Identifier (NSID) handled by this decoder.
+    public let typeIdentifier: String
+
+    /// The closure that decodes the concrete record and wraps it as an ``UnknownType``.
+    ///
+    /// - Returns: An `UnknownType` value that contains the decoded record.
+    private let decodeRecord: @Sendable (Decoder) throws -> UnknownType
+
+    /// Creates a decoder for a concrete record type.
+    ///
+    /// - Parameter type: The concrete ``ATRecordProtocol``-conforming type to decode.
+    public init<Record: ATRecordProtocol>(_ type: Record.Type) {
+        self.typeIdentifier = type.type
+        self.decodeRecord = { decoder in
+            try UnknownType.record(Record(from: decoder))
+        }
+    }
+
+}
+
 /// A registry for all decodable record types in the AT Protocol.
 ///
 /// All record lexicon `struct`s (whether from Bluesky or user created) will be included in

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -120,34 +120,32 @@ public struct ATRecordDecoder: Sendable, Equatable, Hashable {
 
 /// A registry for all decodable record types in the AT Protocol.
 ///
-/// All record lexicon `struct`s (whether from Bluesky or user created) will be included in
-/// the registry. This is used as a map for ``UnknownType`` to find the most appropriate type
-/// that the JSON object will fit into.
+/// The registry maps record NSIDs to ``ATRecordDecoder`` values. ``UnknownType`` uses a snapshot
+/// of this mapping to decode registered records while preserving unregistered records as
+/// ``UnknownType/unknown(_:)`` values.
 ///
 /// This registry is managed by an `actor`, ensuring concurrency-safe access to its internal
 /// data. Because of this, most interactions with `ATRecordTypeRegistry` must be done
 /// asynchronously using `await`.
 ///
-/// When adding a record, you need to type `.self` at the end.
+/// To add a record, create an ``ATRecordDecoder`` from its concrete type.
 /// ```swift
 /// Task {
-///     _ = await ATRecordTypeRegistry.shared.register(types: [UserProfile.self])
+///     let decoder = ATRecordDecoder(type: UserProfile.self)
+///     await ATRecordTypeRegistry.shared.register(types: [decoder])
 /// }
 /// ```
 ///
-/// - Important: Make sure you don't add the same `struct` multiple times.
-///
-/// - Warning: All record types _must_ conform to ``ATRecordProtocol``. Failure to do so may
-/// result in an error.
+/// Registering a decoder whose NSID is already present leaves the existing decoder unchanged.
 ///
 /// # Waiting For the Registry To Be Ready
 ///
-/// If you need to ensure that the registry is ready to be read. In order to do this, you should
-/// use ``ATRecordTypeRegistry/waitUntilRegistryIsRead()`` in the function. This prevents the
-/// function from continuing until the registry is ready to be used.
+/// Use ``ATRecordTypeRegistry/waitUntilRegistryIsRead()`` before reading the registry when
+/// registration may be in progress. This suspends the caller until the current update completes.
 ///
 /// - Note: ``ATRecordTypeRegistry/waitUntilRegistryIsRead()`` only works in functions that
-/// are `async`.
+/// are `async`. This method is only needed when records are registered dynamically; awaiting
+/// ``ATRecordTypeRegistry/register(types:)`` already waits for that registration to finish.
 public actor ATRecordTypeRegistry {
 
     /// The shared instance of `ATRecordTypeRegistry`.
@@ -159,15 +157,13 @@ public actor ATRecordTypeRegistry {
     /// Indicates whether Bluesky record decoders have already been registered.
     private var areBlueskyRecordsRegisteredStorage = false
 
-    /// The registry itself.
+    /// A snapshot of the registry.
     ///
     /// Stores a mapping from Namespaced Identifier (NSID) strings to corresponding record decoders.
     ///
-    /// This contains a `Dictionary`, which contains the value of the `$type` property in the
-    /// lexicon (which is used as the "key"), and the ``ATRecordDecoder`` values for
-    /// ``ATRecordProtocol``-conforming `struct`s. ``UnknownType`` will search for the key that
-    /// matches with the JSON object's `$type` property, and then decode the JSON object using the
-    /// decoder that was found if there's a match.
+    /// The dictionary keys are the `$type` values from record lexicons. Each value is the
+    /// corresponding ``ATRecordDecoder``. The returned dictionary is an isolated copy and does
+    /// not reflect subsequent registrations.
     public static var recordRegistry: [String: ATRecordDecoder] {
         get async {
             await Self.shared.recordRegistrySnapshot()
@@ -192,9 +188,11 @@ public actor ATRecordTypeRegistry {
 
     private init() {}
 
-    /// Registers an array of record types.
+    /// Registers record decoders by their NSIDs.
     ///
-    /// - Parameter types: An array of ``ATRecordProtocol``-conforming `struct`s.
+    /// Decoders with NSIDs that are already registered are ignored.
+    ///
+    /// - Parameter types: The record decoders to register.
     public func register(types: [ATRecordDecoder]) async {
         self.isUpdating = true
 
@@ -211,12 +209,12 @@ public actor ATRecordTypeRegistry {
         await endUpdating()
     }
 
-    /// Registers an array of Bluesky record lexicon types.
+    /// Registers the built-in Bluesky record decoders once.
     ///
     /// - Note: This must only be used for the main `ATProtoKit` `class` and only for
     /// Bluesky-specific record lexicon models.
     ///
-    /// - Parameter blueskyLexiconTypes: An array of ``ATRecordProtocol``-conforming `struct`s.
+    /// - Parameter blueskyLexiconTypes: The Bluesky record decoders to register.
     public func register(blueskyLexiconTypes: [ATRecordDecoder]) async {
         let alreadyRegistered = self.areBlueskyRecordsRegisteredStorage
 
@@ -238,12 +236,10 @@ public actor ATRecordTypeRegistry {
         await endUpdating()
     }
 
-    /// Indicates whether the specified lexicon `struct` type is registered
-    /// inside ``recordRegistry``.
+    /// Indicates whether a decoder is registered for the specified NSID.
     ///
     /// - Parameter typeKey: The Namespaced Identifier (NSID) of the lexicon.
-    /// - Returns: `true` if there is a `struct` that correspondences with the `typeKey` value, or
-    /// `false` if not.
+    /// - Returns: `true` if a decoder is registered for `typeKey`; otherwise, `false`.
     public func isRegistered(_ typeKey: String) -> Bool {
         self.recordRegistryStorage[typeKey] != nil
     }
@@ -264,8 +260,7 @@ public actor ATRecordTypeRegistry {
         }
     }
 
-    /// Attempts to create an instance of a record type based on the provided NSID string
-    /// and decoder.
+    /// Attempts to decode a registered record identified by an NSID.
     ///
     /// While `Codable` allows for polymorphic handling via `enum`s, it has a limitation where it
     /// can't directly decode or encode `protocol`s. This method circumvents this limitation by
@@ -275,12 +270,10 @@ public actor ATRecordTypeRegistry {
     /// - Parameters:
     ///   - type: The Namespaced Identifier (NSID) of the record.
     ///   - decoder: The decoder to read data from.
-    /// - Returns: A `struct` or `class`, which conforms to ``ATRecordProtocol``.
+    /// - Returns: The decoded record wrapped in ``UnknownType/record(_:)``, or `nil` when no
+    /// decoder is registered for `type`.
     ///
-    /// - Throws: An error can occur if one if the following happens:\
-    ///     \- reading from the decoder fails\
-    ///     \- the data read is corrupted or otherwise invalid
-    ///     \- no object key in `recordRegistry` matches the `$type`'s value.
+    /// - Throws: An error if the registered decoder cannot decode the record.
     public static func createInstance(ofType type: String, from decoder: Decoder) async throws -> UnknownType? {
         guard let recordDecoder = await self.getRecordDecoder(for: type) else {
             return nil
@@ -317,7 +310,7 @@ public actor ATRecordTypeRegistry {
         continuations.removeAll()
     }
 
-    /// Retrieves a record decoder by NSID.
+    /// Retrieves a record decoder by Namespaced Identifier (NSID).
     ///
     /// - Parameter type: The NSID string.
     /// - Returns: The registered record decoder, or `nil` if no decoder has been registered.

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -371,7 +371,7 @@ public enum UnknownType: Sendable, Codable {
 
     /// Represents an unknown type.
     ///
-    /// When this is used, the JSON object is converted to `[String: Any]` object. It's your
+    /// When this is used, the JSON object is converted to a `[String: CodableValue]` object. It's your
     /// responsibility to handle this properly.
     case unknown([String: CodableValue])
 
@@ -393,9 +393,8 @@ public enum UnknownType: Sendable, Codable {
 
         if let typeKey = DynamicCodingKeys(stringValue: "$type"),
            let typeIdentifier = try container.decodeIfPresent(String.self, forKey: typeKey),
-           let recordType = ATRecordTypeRegistry.recordRegistry[typeIdentifier] {
-            let record = try recordType.init(from: decoder)
-            self = .record(record)
+           let recordDecoder = Self.recordDecoder(for: typeIdentifier, decoder: decoder) {
+            self = try recordDecoder.decode(from: decoder)
         } else {
             do {
                 let dictionary = try UnknownType.decodeNestedDictionary(container: container)
@@ -507,6 +506,21 @@ public enum UnknownType: Sendable, Codable {
             }
         }
         return dictionary
+    }
+
+    /// Retrieves a registered record decoder from the decoder's user info snapshot.
+    ///
+    /// - Parameters:
+    ///   - type: The NSID string.
+    ///   - decoder: The decoder that may contain a registry snapshot.
+    /// - Returns: The registered record decoder, or `nil` if no matching decoder is available.
+    private static func recordDecoder(for type: String, decoder: Decoder) -> ATRecordDecoder? {
+        guard let key = CodingUserInfoKey(rawValue: ATRecordDecodingUserInfoKey.recordRegistry),
+              let registry = decoder.userInfo[key] as? [String: ATRecordDecoder] else {
+            return nil
+        }
+
+        return registry[type]
     }
 
     /// Decodes a nested array from an unknown JSON object.

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -528,7 +528,7 @@ public enum UnknownType: Sendable, Codable {
     /// This is essential to decode truly unknown types.
     ///
     /// - Parameter container: The container that the JSON object resides in.
-    /// - An `[Any]` object.
+    /// - Returns: An array of ``CodableValue`` elements.
     /// 
     /// - Throws: A `DecodingError` if there's a type mismatch.
     private static func decodeArray(from container: KeyedDecodingContainer<DynamicCodingKeys>, forKey key: DynamicCodingKeys) throws -> [CodableValue] {

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -91,7 +91,7 @@ public struct ATRecordDecoder: Sendable, Equatable, Hashable {
     /// Creates a decoder for a concrete record type.
     ///
     /// - Parameter type: The concrete ``ATRecordProtocol``-conforming type to decode.
-    public init<Record: ATRecordProtocol>(_ type: Record.Type) {
+    public init<Record: ATRecordProtocol>(type: Record.Type) {
         self.typeIdentifier = type.type
         self.decodeRecord = { decoder in
             try UnknownType.record(Record(from: decoder))

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -152,26 +152,24 @@ public actor ATRecordTypeRegistry {
     /// The shared instance of `ATRecordTypeRegistry`.
     public static let shared = ATRecordTypeRegistry()
 
-    /// A private dispatch queue for the registry.
-    private let registryQueue = DispatchQueue(label: "com.cjrriley.ATProtoKit.ATRecordTypeRegistryQueue")
+    /// The registered record decoders keyed by the Namespaced Identifier (NSID).
+    private var recordRegistryStorage: [String: ATRecordDecoder] = [:]
 
-    /// A private property of ``recordRegistry``.
-    private(set) static var _recordRegistry: [String: any ATRecordProtocol.Type] = [:]
+    /// Indicates whether Bluesky record decoders have already been registered.
+    private var areBlueskyRecordsRegisteredStorage = false
 
     /// The registry itself.
     ///
-    /// Stores a mapping from Namespaced Identifier (NSID) strings to corresponding record types.
+    /// Stores a mapping from Namespaced Identifier (NSID) strings to corresponding record decoders.
     ///
     /// This contains a `Dictionary`, which contains the value of the `$type` property in the
-    /// lexicon (which is used as the "key"), and the ``ATRecordProtocol``-conforming `struct`s
-    /// (which is used as the "value"). ``UnknownType`` will search for the key that matches with
-    /// the JSON object's `$type` property, and then decode or encode the JSON object using the
-    /// `struct` that was found if there's a match.
-    public static var recordRegistry: [String: any ATRecordProtocol.Type] {
-        get {
-            return self.shared.registryQueue.sync {
-                Self._recordRegistry
-            }
+    /// lexicon (which is used as the "key"), and the ``ATRecordDecoder`` values for
+    /// ``ATRecordProtocol``-conforming `struct`s. ``UnknownType`` will search for the key that
+    /// matches with the JSON object's `$type` property, and then decode the JSON object using the
+    /// decoder that was found if there's a match.
+    public static var recordRegistry: [String: ATRecordDecoder] {
+        get async {
+            await Self.shared.recordRegistrySnapshot()
         }
     }
 
@@ -179,7 +177,11 @@ public actor ATRecordTypeRegistry {
     /// added to ``recordRegistry``. Defaults to `false`.
     ///
     /// - Warning: Don't touch this property; this should only be used for ``ATProtoKit``.
-    public private(set) static var areBlueskyRecordsRegistered = false
+    public static var areBlueskyRecordsRegistered: Bool {
+        get async {
+            await Self.shared.areBlueskyRecordsRegisteredStorage
+        }
+    }
 
     /// Tracks whether the registry is currently being modified.
     public private(set) var isUpdating = false
@@ -192,19 +194,17 @@ public actor ATRecordTypeRegistry {
     /// Registers an array of record types.
     ///
     /// - Parameter types: An array of ``ATRecordProtocol``-conforming `struct`s.
-    public func register(types: [any ATRecordProtocol.Type]) async {
+    public func register(types: [ATRecordDecoder]) async {
         self.isUpdating = true
 
         for type in types {
-            let typeKey = type.type
+            let typeKey = type.typeIdentifier
             guard !self.isRegistered(typeKey) else {
                 print("Record type '\(typeKey)' is already registered. Skipping.")
                 continue
             }
 
-            self.registryQueue.sync {
-                Self._recordRegistry[typeKey] = type
-            }
+            self.recordRegistryStorage[typeKey] = type
         }
 
         await endUpdating()
@@ -216,31 +216,24 @@ public actor ATRecordTypeRegistry {
     /// Bluesky-specific record lexicon models.
     ///
     /// - Parameter blueskyLexiconTypes: An array of ``ATRecordProtocol``-conforming `struct`s.
-    public func register(blueskyLexiconTypes: [any ATRecordProtocol.Type]) async {
-        let alreadyRegistered = self.registryQueue.sync {
-            Self.areBlueskyRecordsRegistered
-        }
+    public func register(blueskyLexiconTypes: [ATRecordDecoder]) async {
+        let alreadyRegistered = self.areBlueskyRecordsRegisteredStorage
 
         guard !alreadyRegistered else { return }
 
         self.isUpdating = true
 
         for type in blueskyLexiconTypes {
-            let typeKey = type.type
+            let typeKey = type.typeIdentifier
             guard !isRegistered(typeKey) else {
                 print("Record type '\(typeKey)' is already registered. Skipping.")
                 continue
             }
 
-            self.registryQueue.sync {
-                Self._recordRegistry[typeKey] = type
-            }
+            self.recordRegistryStorage[typeKey] = type
         }
 
-        self.registryQueue.sync {
-            Self.areBlueskyRecordsRegistered = true
-        }
-
+        self.areBlueskyRecordsRegisteredStorage = true
         await endUpdating()
     }
 
@@ -251,16 +244,14 @@ public actor ATRecordTypeRegistry {
     /// - Returns: `true` if there is a `struct` that correspondences with the `typeKey` value, or
     /// `false` if not.
     public func isRegistered(_ typeKey: String) -> Bool {
-        return self.registryQueue.sync { Self._recordRegistry[typeKey] != nil }
+        self.recordRegistryStorage[typeKey] != nil
     }
 
     /// Sets ``areBlueskyRecordsRegistered`` to a `Bool` value.
     ///
     /// - Parameter value: The `Bool` value used to set the property.
-    public static func setBlueskyRecordsRegistered(_ value: Bool) {
-        self.shared.registryQueue.sync {
-            Self.areBlueskyRecordsRegistered = value
-        }
+    public static func setBlueskyRecordsRegistered(_ value: Bool) async {
+        await Self.shared.setBlueskyRecordsRegisteredStorage(value)
     }
 
     /// Halts the execution of code until ``recordRegistry`` is ready to be used.
@@ -289,24 +280,29 @@ public actor ATRecordTypeRegistry {
     ///     \- reading from the decoder fails\
     ///     \- the data read is corrupted or otherwise invalid
     ///     \- no object key in `recordRegistry` matches the `$type`'s value.
-    public static func createInstance(ofType type: String, from decoder: Decoder) throws -> (any ATRecordProtocol)? {
-        guard let typeClass = self.getRecordType(for: type) else {
+    public static func createInstance(ofType type: String, from decoder: Decoder) async throws -> UnknownType? {
+        guard let recordDecoder = await self.getRecordDecoder(for: type) else {
             return nil
         }
 
         // Instantiate the record from the decoder
-        return try typeClass.init(from: decoder)
+        return try recordDecoder.decode(from: decoder)
     }
 
-    /// Retrieves a specific record type based on the Namespaced Identifier (NSID) of the record.
+    /// Retrieves a specific record decoder based on the Namespaced Identifier (NSID) of the record.
     /// 
     /// - Parameter type: The NSID string.
-    /// - Returns: The ``ATRecordProtocol``-conforming type (if there's a match), or `nil`
+    /// - Returns: The ``ATRecordDecoder`` value (if there's a match), or `nil`
     /// (if there isn't).
-    public static func getRecordType(for type: String) -> (any ATRecordProtocol.Type)? {
-        self.shared.registryQueue.sync {
-            return ATRecordTypeRegistry.recordRegistry[type]
-        }
+    public static func getRecordDecoder(for type: String) async -> ATRecordDecoder? {
+        await Self.shared.recordDecoder(for: type)
+    }
+
+    /// Returns a snapshot of the current registry.
+    ///
+    /// - Returns: The registered record decoders keyed by NSID.
+    public func recordRegistrySnapshot() -> [String: ATRecordDecoder] {
+        self.recordRegistryStorage
     }
 
     /// Called when ``recordRegistry`` updates are completed.
@@ -319,9 +315,22 @@ public actor ATRecordTypeRegistry {
         // Clear the waiting list.
         continuations.removeAll()
     }
-Data
 
-Data
+    /// Retrieves a record decoder by NSID.
+    ///
+    /// - Parameter type: The NSID string.
+    /// - Returns: The registered record decoder, or `nil` if no decoder has been registered.
+    private func recordDecoder(for type: String) -> ATRecordDecoder? {
+        self.recordRegistryStorage[type]
+    }
+
+    /// Updates the Bluesky registration marker.
+    ///
+    /// - Parameter value: The new registration marker value.
+    private func setBlueskyRecordsRegisteredStorage(_ value: Bool) {
+        self.areBlueskyRecordsRegisteredStorage = value
+    }
+}
 
 /// A user info key used to pass record decoder snapshots into `Decoder` instances.
 internal enum ATRecordDecodingUserInfoKey {

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -98,6 +98,16 @@ public struct ATRecordDecoder: Sendable, Equatable, Hashable {
         }
     }
 
+    /// Creates an ``UnknownType`` record from the provided decoder.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    /// - Returns: The decoded record wrapped as an ``UnknownType``.
+    ///
+    /// - Throws: An error is thrown if the concrete record type cannot be decoded.
+    public func decode(from decoder: Decoder) throws -> UnknownType {
+        try decodeRecord(decoder)
+    }
+
     public static func == (lhs: ATRecordDecoder, rhs: ATRecordDecoder) -> Bool {
         lhs.typeIdentifier == rhs.typeIdentifier
     }

--- a/Sources/ATProtoKit/Utilities/Extensions/ExtensionHelpers.swift
+++ b/Sources/ATProtoKit/Utilities/Extensions/ExtensionHelpers.swift
@@ -193,3 +193,18 @@ extension URL {
 
 // MARK: - JobStatusDefinition Extension
 extension AppBskyLexicon.Video.JobStatusDefinition: Error {}
+
+// MARK: - JSONDecoder Extension
+extension JSONDecoder {
+
+    /// Adds a record registry snapshot to the decoder's user info dictionary.
+    ///
+    /// - Parameter recordRegistry: The record decoder snapshot to use while decoding.
+    public func useRecordRegistrySnapshot(_ recordRegistry: [String: ATRecordDecoder]) {
+        guard let key = CodingUserInfoKey(rawValue: ATRecordDecodingUserInfoKey.recordRegistry) else {
+            return
+        }
+
+        self.userInfo[key] = recordRegistry
+    }
+}


### PR DESCRIPTION
## Description
This pull request addresses the feature request in Issue #266. These changes add functionality to save, update, and delete drafts, and also introduce the type definitions used by these functions.

## Linked Issues
#266

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
I prepared the documentation based on existing materials.
Also, since the fix for the bug related to Drafts has not yet been applied to the `develop` branch, this function does not currently work. I would like to confirm whether I should submit a PR that fixes this bug as well, or if it is not necessary to include it here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
