### PR TITLE
Add draft management APIs and related type definitions

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftCreateDraftMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftCreateDraftMethod.swift
@@ -1,0 +1,68 @@
+//
+//  AppBskyDraftCreateDraftMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Creates a draft on the user's account.
+    ///
+    /// Drafts are server-synced post drafts stored in the user's private storage (stash).
+    ///
+    /// - Note: According to the AT Protocol specifications: "Inserts a draft using private storage (stash). An upper limit of drafts might be enforced.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.createDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/createDraft.json
+    ///
+    /// - Parameter draft: The draft to be created.
+    /// - Returns: The TID identifier assigned to the newly-created draft.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func createDraft(
+        _ draft: AppBskyLexicon.Draft.DraftDefinition
+    ) async throws -> AppBskyLexicon.Draft.CreateDraftOutput {
+        guard let session = try await self.getUserSession(),
+              let keychain = sessionConfiguration?.keychainProtocol else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        try await sessionConfiguration?.ensureValidToken()
+        let accessToken = try await keychain.retrieveAccessToken()
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.draft.createDraft") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = AppBskyLexicon.Draft.CreateDraftRequestBody(draft: draft)
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                authorizationValue: "Bearer \(accessToken)"
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: AppBskyLexicon.Draft.CreateDraftOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftDeleteDraftMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftDeleteDraftMethod.swift
@@ -1,0 +1,61 @@
+//
+//  AppBskyDraftDeleteDraftMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Deletes a draft on the user's account.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Deletes a draft by ID.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.deleteDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/deleteDraft.json
+    ///
+    /// - Parameter id: The TID identifier of the draft to delete.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func deleteDraft(id: String) async throws {
+        guard let session = try await self.getUserSession(),
+              let keychain = sessionConfiguration?.keychainProtocol else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        try await sessionConfiguration?.ensureValidToken()
+        let accessToken = try await keychain.retrieveAccessToken()
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.draft.deleteDraft") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = AppBskyLexicon.Draft.DeleteDraftRequestBody(id: id)
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                authorizationValue: "Bearer \(accessToken)"
+            )
+
+            _ = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody
+            )
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftGetDraftsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftGetDraftsMethod.swift
@@ -1,0 +1,86 @@
+//
+//  AppBskyDraftGetDraftsMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Retrieves the drafts for the authenticated user.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Gets views of user drafts.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.getDrafts`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/getDrafts.json
+    ///
+    /// - Parameters:
+    ///   - limit: The number of drafts to return. Optional. Defaults to `50`.
+    ///   Can only choose between 1 and 100.
+    ///   - cursor: The mark used to indicate the starting point for the next set
+    ///   of results. Optional.
+    /// - Returns: An array of drafts, with an optional cursor to expand the array.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getDrafts(
+        limit: Int? = 50,
+        cursor: String? = nil
+    ) async throws -> AppBskyLexicon.Draft.GetDraftsOutput {
+        guard let session = try await self.getUserSession(),
+              let keychain = sessionConfiguration?.keychainProtocol else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        try await sessionConfiguration?.ensureValidToken()
+        let accessToken = try await keychain.retrieveAccessToken()
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.draft.getDrafts") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        if let limit {
+            let finalLimit = max(1, min(limit, 100))
+            queryItems.append(("limit", "\(finalLimit)"))
+        }
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                authorizationValue: "Bearer \(accessToken)"
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: AppBskyLexicon.Draft.GetDraftsOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftUpdateDraftMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyDraftUpdateDraftMethod.swift
@@ -1,0 +1,68 @@
+//
+//  AppBskyDraftUpdateDraftMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Updates an existing draft on the user's account.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Updates a draft using private storage (stash). If the draft ID points to a non-existing ID, the update will be silently ignored. This is done because updates don't enforce draft limit, so it accepts all writes, but will ignore invalid ones.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.updateDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/updateDraft.json
+    ///
+    /// - Parameters:
+    ///   - id: The TID identifier of the draft to update.
+    ///   - draft: The new contents of the draft.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func updateDraft(
+        id: String,
+        with draft: AppBskyLexicon.Draft.DraftDefinition
+    ) async throws {
+        guard let session = try await self.getUserSession(),
+              let keychain = sessionConfiguration?.keychainProtocol else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        try await sessionConfiguration?.ensureValidToken()
+        let accessToken = try await keychain.retrieveAccessToken()
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.draft.updateDraft") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = AppBskyLexicon.Draft.UpdateDraftRequestBody(
+            draft: AppBskyLexicon.Draft.DraftWithIdDefinition(tid: id, draft: draft)
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                authorizationValue: "Bearer \(accessToken)"
+            )
+
+            _ = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody
+            )
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftCreateDraft.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftCreateDraft.swift
@@ -1,0 +1,46 @@
+//
+//  AppBskyDraftCreateDraft.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Draft {
+
+    /// A request body model for creating a draft.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Inserts a draft using private storage (stash). An upper limit of drafts might be enforced.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.createDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/createDraft.json
+    public struct CreateDraftRequestBody: Sendable, Codable {
+
+        /// The draft to be created.
+        public let draft: AppBskyLexicon.Draft.DraftDefinition
+
+        public init(draft: AppBskyLexicon.Draft.DraftDefinition) {
+            self.draft = draft
+        }
+    }
+
+    /// An output model for creating a draft.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Creates a draft.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.createDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/createDraft.json
+    public struct CreateDraftOutput: Sendable, Codable {
+
+        /// The TID identifier assigned to the newly-created draft.
+        public let id: String
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftDefs.swift
@@ -19,7 +19,7 @@ extension AppBskyLexicon.Draft {
         /// The identifier of the lexicon.
         ///
         /// - Warning: The value must not change.
-        public static let type: String = "app.bsky.drafts.defs#draftWithId"
+        public static let type: String = "app.bsky.draft.defs#draftWithId"
         
         /// A TID to be used as a draft identifier.
         public let tid: String
@@ -64,7 +64,7 @@ extension AppBskyLexicon.Draft {
         /// The identifier of the lexicon.
         ///
         /// - Warning: The value must not change.
-        public static let type: String = "app.bsky.drafts.defs#draft"
+        public static let type: String = "app.bsky.draft.defs#draft"
         
         /// UUIDv4 identifier of the device that created this draft. Optional.
         ///
@@ -249,7 +249,7 @@ extension AppBskyLexicon.Draft {
         /// The identifier of the lexicon.
         ///
         /// - Warning: The value must not change.
-        public static let type: String = "app.bsky.drafts.defs#draftPost"
+        public static let type: String = "app.bsky.draft.defs#draftPost"
         
         /// The primary post content.
         ///
@@ -381,7 +381,7 @@ extension AppBskyLexicon.Draft {
         /// The identifier of the lexicon.
         ///
         /// - Warning: The value must not change.
-        public static let type: String = "app.bsky.drafts.defs#draftView"
+        public static let type: String = "app.bsky.draft.defs#draftView"
         
         /// A TID to be used as a draft identifier.
         public let tid: String
@@ -588,7 +588,7 @@ extension AppBskyLexicon.Draft {
         /// The identifier of the lexicon.
         ///
         /// - Warning: The value must not change.
-        public static let type: String = "app.bsky.drafts.defs#draftEmbedImage"
+        public static let type: String = "app.bsky.draft.defs#draftEmbedImage"
         
         /// A reference to the image, local to the drafting device
         public let localRef: DraftEmbedLocalReferenceDefinition

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftDeleteDraft.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftDeleteDraft.swift
@@ -1,0 +1,32 @@
+//
+//  AppBskyDraftDeleteDraft.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Draft {
+
+    /// A request body model for deleting a draft.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Deletes a draft by ID.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.deleteDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/deleteDraft.json
+    public struct DeleteDraftRequestBody: Sendable, Codable {
+
+        /// The TID identifier of the draft to delete.
+        public let id: String
+
+        public init(id: String) {
+            self.id = id
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftGetDrafts.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftGetDrafts.swift
@@ -1,0 +1,31 @@
+//
+//  AppBskyDraftGetDrafts.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Draft {
+
+    /// An output model for retrieving drafts.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Gets views of user drafts.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.getDrafts`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/getDrafts.json
+    public struct GetDraftsOutput: Sendable, Codable {
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+
+        /// An array of drafts.
+        public let drafts: [AppBskyLexicon.Draft.DraftViewDefinition]
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftUpdateDraft.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Draft/AppBskyDraftUpdateDraft.swift
@@ -1,0 +1,32 @@
+//
+//  AppBskyDraftUpdateDraft.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-06-21.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Draft {
+
+    /// A request body model for updating an existing draft.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Updates a draft using private storage (stash). If the draft ID points to a non-existing ID, the update will be silently ignored. This is done because updates don't enforce draft limit, so it accepts all writes, but will ignore invalid ones.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.draft.updateDraft`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/draft/updateDraft.json
+    public struct UpdateDraftRequestBody: Sendable, Codable {
+
+        /// The draft to be updated, containing its identifier.
+        public let draft: AppBskyLexicon.Draft.DraftWithIdDefinition
+
+        public init(draft: AppBskyLexicon.Draft.DraftWithIdDefinition) {
+            self.draft = draft
+        }
+    }
+}


### PR DESCRIPTION
## Description
This pull request addresses the feature request in Issue #266. These changes add functionality to save, update, and delete drafts, and also introduce the type definitions used by these functions.

## Linked Issues
#266

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
I prepared the documentation based on existing materials.
Also, since the fix for the bug related to Drafts has not yet been applied to the `develop` branch, this function does not currently work. I would like to confirm whether I should submit a PR that fixes this bug as well, or if it is not necessary to include it here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]