### PR TITLE
Deprecate getTaggedSuggestions method

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTaggedSuggestionsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyUnspeccedGetTaggedSuggestionsMethod.swift
@@ -28,6 +28,7 @@ extension ATProtoKit {
     /// 
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    @available(*, deprecated, message: "Unmaintained upstream route. Use getSuggestedUsers(category:limit:) or getSuggestedFeeds(limit:cursor:) instead.")
     public func getTaggedSuggestions() async throws -> AppBskyLexicon.Unspecced.GetTaggedSuggestionsOutput {
         guard let requestURL = URL(string: "\(self.pdsURL)/xrpc/app.bsky.unspecced.getTaggedSuggestions") else {
             throw ATRequestPrepareError.invalidRequestURL


### PR DESCRIPTION
## Description
This pull request marks `getTaggedSuggestions()` as deprecated. The underlying `app.bsky.unspecced.getTaggedSuggestions` route is no longer maintained upstream, so callers are guided toward `getSuggestedUsers(category:limit:)` for user suggestions and `getSuggestedFeeds(limit:cursor:)` for feed suggestions via an `@available(*, deprecated, message:)` attribute.

## Linked Issues
#272

## Type of Change
- [ ] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
This change does not fit cleanly into the existing categories (it is a deprecation, not a bug fix or new feature), so no Type of Change is selected. Only the `@available(*, deprecated, message:)` attribute is added; the method body, signature, and DocC comments are left unchanged, so existing callers continue to compile with a deprecation warning and can migrate to the suggested replacements incrementally.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]