### PR TITLE
Fix sendInteractions(_:) request encoding and routing

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedSendInteractionsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedSendInteractionsMethod.swift
@@ -24,13 +24,16 @@ extension ATProtoKit {
     /// 
     /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/feed/sendInteractions.json
     ///
-    /// - Parameter interactions: An array of interactions.
+    /// - Parameters:
+    ///   - interactions: An array of interactions.
+    ///   - feedGeneratorDID: The DID of the feed generator to route the request to. Optional.
     /// - Returns: An array of interactions.
     ///
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func sendInteractions(
-        _ interactions: [AppBskyLexicon.Feed.InteractionDefinition]
+        _ interactions: [AppBskyLexicon.Feed.InteractionDefinition],
+        feedGeneratorDID: String? = nil
     ) async throws -> AppBskyLexicon.Feed.SendInteractionsOutput {
         guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
@@ -55,7 +58,8 @@ extension ATProtoKit {
                 andMethod: .post,
                 acceptValue: nil,
                 contentTypeValue: nil,
-                authorizationValue: "Bearer \(accessToken)"
+                authorizationValue: "Bearer \(accessToken)",
+                proxyValue: feedGeneratorDID.map { "\($0)#bsky_fg" }
             )
             let response = try await apiClientService.sendRequest(
                 request,

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedSendInteractionsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedSendInteractionsMethod.swift
@@ -57,7 +57,7 @@ extension ATProtoKit {
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: nil,
-                contentTypeValue: nil,
+                contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)",
                 proxyValue: feedGeneratorDID.map { "\($0)#bsky_fg" }
             )

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedDefs.swift
@@ -1237,85 +1237,85 @@ extension AppBskyLexicon.Feed {
         /// - SeeAlso: This is based on the [`app.bsky.feed.defs`][github] lexicon.
         ///
         /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/feed/defs.json
-        public enum Event: Sendable, Codable {
+        public enum Event: String, Sendable, Codable {
 
             /// Indicates the feed generator should request less content similar to the feed's item.
             ///
             /// - Note: According to the AT Protocol specifications: "Request that less content like the
             /// given feed item be shown in the feed."
-            case requestLess
+            case requestLess = "app.bsky.feed.defs#requestLess"
 
             /// Indicates the feed generator should request more content similar to the feed's item.
             ///
             /// - Note: According to the AT Protocol specifications: "Request that more content like the
             /// given feed item be shown in the feed."
-            case requestMore
+            case requestMore = "app.bsky.feed.defs#requestMore"
 
             /// Indicates the feed generator clicked on the feed's item.
             ///
             /// - Note: According to the AT Protocol specifications: "User clicked through to the
             /// feed item."
-            case clickthroughItem
+            case clickthroughItem = "app.bsky.feed.defs#clickthroughItem"
 
             /// Indicates the user clicked on the author of the feed's item.
             ///
             /// - Note: According to the AT Protocol specifications: "User clicked through to the author
             /// of the feed item."
-            case clickthroughAuthor
+            case clickthroughAuthor = "app.bsky.feed.defs#clickthroughAuthor"
 
             /// Indicates the user clicked on the reposter of the feed's item.
             ///
             /// - Note: According to the AT Protocol specifications: "User clicked through to the reposter
             /// of the feed item."
-            case clickthroughReposter
+            case clickthroughReposter = "app.bsky.feed.defs#clickthroughReposter"
 
             /// Indicates the user clicked on the embedded content of the feed's item.
             ///
             /// - Note: According to the AT Protocol specifications: "User clicked through to the embedded
             /// content of the feed item."
-            case clickthroughEmbed
+            case clickthroughEmbed = "app.bsky.feed.defs#clickthroughEmbed"
 
             /// Declares the feed generator supports any post type.
             ///
             /// - Note: According to the AT Protocol specifications: "Declares the feed generator
             /// returns any types of posts."
-            case contentModeUnspecified
+            case contentModeUnspecified = "app.bsky.feed.defs#contentModeUnspecified"
 
             /// Declares the feed generator returns posts with embeds from `app.bsky.embed.video`.
             ///
             /// - Note: According to the AT Protocol specifications: "Declares the feed generator
             /// returns posts containing app.bsky.embed.video embeds."
-            case contentModeVideo
+            case contentModeVideo = "app.bsky.feed.defs#contentModeVideo"
 
             /// Indicates the user has viewed the item in the feed.
             ///
             /// - Note: According to the AT Protocol specifications: "Feed item was seen by user."
-            case interactionSeen
+            case interactionSeen = "app.bsky.feed.defs#interactionSeen"
 
             /// Indicates the user has liked the item of the feed.
             ///
             /// - Note: According to the AT Protocol specifications: "User liked the feed item."
-            case interactionLike
+            case interactionLike = "app.bsky.feed.defs#interactionLike"
 
             /// Indicates the user has reposted the item of the feed.
             ///
             /// - Note: According to the AT Protocol specifications: "User reposted the feed item."
-            case interactionRepost
+            case interactionRepost = "app.bsky.feed.defs#interactionRepost"
 
             /// Indicates the user has replied to the item of the feed.
             ///
             /// - Note: According to the AT Protocol specifications: "User replied to the feed item."
-            case interactionReply
+            case interactionReply = "app.bsky.feed.defs#interactionReply"
 
             /// Indicates the user has quote posted the feed's item.
             ///
             /// - Note: According to the AT Protocol specifications: "User quoted the feed item."
-            case interactionQuote
+            case interactionQuote = "app.bsky.feed.defs#interactionQuote"
 
             /// Indicates the user has shared the feed's item.
             ///
             /// - Note: According to the AT Protocol specifications: "User shared the feed item."
-            case interactionShare
+            case interactionShare = "app.bsky.feed.defs#interactionShare"
         }
     }
 }


### PR DESCRIPTION
## Description
This pull request addresses the issues reported in #280 and #281.

The sendInteractions(_:) implementation has been updated to send requests in a format accepted by feed generators. This includes setting the appropriate Content-Type header for JSON payloads and adding support for the atproto-proxy header so requests can be routed to feed generator services as required by the AT Protocol specification.

In addition, AppBskyLexicon.Feed.InteractionDefinition.Event has been updated to encode and decode using the lexicon-defined string values. The previous implementation relied on Swift’s default enum Codable synthesis, which produced a JSON structure that does not match the format expected by the protocol.

These fixes are closely related and are required together for sendInteractions(_:) requests to succeed end-to-end when communicating with feed generators.

## Linked Issues
#280
#281


## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
N/A

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
