### PR TITLE
Fix 13 procedure wrappers using GET instead of POST

### DIFF
--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteSetAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteSetAsAdmin.swift
@@ -47,7 +47,7 @@ extension ATProtoAdmin {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteValuesAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteValuesAsAdmin.swift
@@ -52,7 +52,7 @@ extension ATProtoAdmin {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/RemoveOptionsAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/RemoveOptionsAsAdmin.swift
@@ -45,7 +45,7 @@ extension ATProtoAdmin {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpsertSetAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/UpsertSetAsAdmin.swift
@@ -52,7 +52,7 @@ extension ATProtoAdmin {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)"

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyActorDeleteAccountMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyActorDeleteAccountMethod.swift
@@ -40,7 +40,7 @@ extension ATProtoBlueskyChat {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
                 authorizationValue: "Bearer \(accessToken)",

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoAcceptConvoMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoAcceptConvoMethod.swift
@@ -43,7 +43,7 @@ extension ATProtoBlueskyChat {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)",

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoAddReactionMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoAddReactionMethod.swift
@@ -56,7 +56,7 @@ extension ATProtoBlueskyChat {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)",

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoDeleteMessageForSelfMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoDeleteMessageForSelfMethod.swift
@@ -49,7 +49,7 @@ extension ATProtoBlueskyChat {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)",

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoRemoveReactionMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoRemoveReactionMethod.swift
@@ -56,7 +56,7 @@ extension ATProtoBlueskyChat {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)",

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoSendMessageBatchMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoSendMessageBatchMethod.swift
@@ -47,7 +47,7 @@ extension ATProtoBlueskyChat {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)",

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoUpdateAllReadMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoUpdateAllReadMethod.swift
@@ -45,7 +45,7 @@ extension ATProtoBlueskyChat {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: "application/json",
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)",

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyModerationUpdateActorAccessMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyModerationUpdateActorAccessMethod.swift
@@ -54,7 +54,7 @@ extension ATProtoBlueskyChat {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: nil,
                 contentTypeValue: "application/json",
                 authorizationValue: "Bearer \(accessToken)",

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoImportRepoMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoImportRepoMethod.swift
@@ -45,7 +45,7 @@ extension ATProtoKit {
         do {
             let request = apiClientService.createRequest(
                 forRequest: requestURL,
-                andMethod: .get,
+                andMethod: .post,
                 acceptValue: nil,
                 contentTypeValue: "application/vnd.ipld.car",
                 authorizationValue: nil


### PR DESCRIPTION
## Description
This pull request fixes 13 procedure wrappers that were incorrectly creating requests with the HTTP GET method while also attaching a JSON request body.

According to the AT Protocol XRPC specification, procedure endpoints must be invoked using HTTP POST. Because these wrappers used GET requests with a body, CFNetwork rejected them locally with NSURLErrorDomain Code=-1103 (“GET method must not have a body”), preventing the requests from ever reaching the server.

This change updates the affected wrappers to use .post instead of .get, bringing their implementation into compliance with the XRPC specification and allowing requests to be transmitted successfully.

No API changes were made. The only modification is the HTTP method used when constructing requests for the affected procedure endpoints.

## Linked Issues
#283

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
No documentation changes were required for this fix.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
