### PR TITLE
Support Non-Bsky PDS Names for DMs

### DIFF
--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyActorDeleteAccountMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyActorDeleteAccountMethod.swift
@@ -23,15 +23,15 @@ extension ATProtoBlueskyChat {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func deleteAccount() async throws {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.actor.deleteAccount") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.actor.deleteAccount") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyActorExportAccountDataMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyActorExportAccountDataMethod.swift
@@ -23,15 +23,15 @@ extension ATProtoBlueskyChat {
     ///- Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func exportAccountData() async throws -> Data {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.actor.exportAccountData") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.actor.exportAccountData") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoAcceptConvoMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoAcceptConvoMethod.swift
@@ -24,15 +24,15 @@ extension ATProtoBlueskyChat {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func acceptConversation(by id: String) async throws -> ChatBskyLexicon.Conversation.AcceptConversationOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.acceptConvo") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.acceptConvo") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoAddReactionMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoAddReactionMethod.swift
@@ -35,15 +35,15 @@ extension ATProtoBlueskyChat {
         for messageID: String,
         value: String
     ) async throws -> ChatBskyLexicon.Conversation.AddReactionOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.addReaction") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.addReaction") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoDeleteMessageForSelfMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoDeleteMessageForSelfMethod.swift
@@ -29,15 +29,15 @@ extension ATProtoBlueskyChat {
         conversationID: String,
         messageID: String
     ) async throws -> ChatBskyLexicon.Conversation.DeletedMessageViewDefinition {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.deleteMessageForSelf") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.deleteMessageForSelf") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoGetConvoAvailabilityMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoGetConvoAvailabilityMethod.swift
@@ -29,15 +29,15 @@ extension ATProtoBlueskyChat {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func getConversationAvailability(members: [String]) async throws -> ChatBskyLexicon.Conversation.GetConversationAvailabilityOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.getConvoAvailability") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.getConvoAvailability") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoGetConvoForMembersMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoGetConvoForMembersMethod.swift
@@ -28,15 +28,15 @@ extension ATProtoBlueskyChat {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func getConversaionForMembers(_ members: [String]) async throws -> ChatBskyLexicon.Conversation.GetConversationForMembersOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.getConvoForMembers") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.getConvoForMembers") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoGetConvoMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoGetConvoMethod.swift
@@ -24,15 +24,15 @@ extension ATProtoBlueskyChat {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func getConversation(by id: String) async throws -> ChatBskyLexicon.Conversation.GetConversationOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.getConvo") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.getConvo") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoGetLogMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoGetLogMethod.swift
@@ -25,15 +25,15 @@ extension ATProtoBlueskyChat {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func getLog(cursor: String? = nil) async throws -> ChatBskyLexicon.Conversation.GetLogOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.getLog") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.getLog") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoGetMessagesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoGetMessagesMethod.swift
@@ -30,15 +30,15 @@ extension ATProtoBlueskyChat {
         from conversationID: String,
         limit: Int? = 50
     ) async throws -> ChatBskyLexicon.Conversation.GetMessagesOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.getMessages") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.getMessages") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoLeaveConvoMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoLeaveConvoMethod.swift
@@ -24,15 +24,15 @@ extension ATProtoBlueskyChat {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func leaveConversation(from id: String) async throws -> ChatBskyLexicon.Conversation.LeaveConversationOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.leaveConvo") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.leaveConvo") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoListConvosMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoListConvosMethod.swift
@@ -35,15 +35,15 @@ extension ATProtoBlueskyChat {
         readState: ChatBskyLexicon.Conversation.ListConversations.ReadState? = nil,
         status: ChatBskyLexicon.Conversation.ListConversations.Status? = nil
     ) async throws -> ChatBskyLexicon.Conversation.ListConversationsOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.listConvos") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.listConvos") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoMuteConvoMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoMuteConvoMethod.swift
@@ -24,15 +24,15 @@ extension ATProtoBlueskyChat {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func muteConversation(from id: String) async throws -> ChatBskyLexicon.Conversation.MuteConversationOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.muteConvo") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.muteConvo") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoRemoveReactionMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoRemoveReactionMethod.swift
@@ -35,15 +35,15 @@ extension ATProtoBlueskyChat {
         for messageID: String,
         value: String
     ) async throws -> ChatBskyLexicon.Conversation.RemoveReactionOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.removeReaction") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.removeReaction") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoSendMessageBatchMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoSendMessageBatchMethod.swift
@@ -28,15 +28,15 @@ extension ATProtoBlueskyChat {
     public func sendMessageBatch(
         _ messages: [ChatBskyLexicon.Conversation.SendMessageBatch.BatchItem]
     ) async throws -> ChatBskyLexicon.Conversation.SendMessageBatchOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.sendMessageBatch") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.sendMessageBatch") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoSendMessageMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoSendMessageMethod.swift
@@ -31,15 +31,15 @@ extension ATProtoBlueskyChat {
         to conversationID: String,
         message: ChatBskyLexicon.Conversation.MessageInputDefinition
     ) async throws -> ChatBskyLexicon.Conversation.MessageViewDefinition {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.sendMessage") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.sendMessage") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoUnmuteConvoMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoUnmuteConvoMethod.swift
@@ -24,15 +24,15 @@ extension ATProtoBlueskyChat {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func unmuteConversation(by id: String) async throws -> ChatBskyLexicon.Conversation.UnmuteConversationOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.unmuteConvo") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.unmuteConvo") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoUpdateAllReadMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoUpdateAllReadMethod.swift
@@ -26,15 +26,15 @@ extension ATProtoBlueskyChat {
     public func updateAllRead(
         status: ChatBskyLexicon.Conversation.UpdateAllRead.Status? = nil
     ) async throws -> ChatBskyLexicon.Conversation.UpdateAllReadOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.updateAllRead") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.updateAllRead") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoUpdateReadMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyConvoUpdateReadMethod.swift
@@ -29,15 +29,15 @@ extension ATProtoBlueskyChat {
         from conversationID: String,
         to messageID: String? = nil
     ) async throws -> ChatBskyLexicon.Conversation.UpdateReadOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.convo.updateRead") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.convo.updateRead") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyModerationGetActorMetadataMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyModerationGetActorMetadataMethod.swift
@@ -30,15 +30,15 @@ extension ATProtoBlueskyChat {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func getMessageContext(actorDID: String) async throws -> ChatBskyLexicon.Moderation.GetActorMetadataOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.moderation.getActorMetadata") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.moderation.getActorMetadata") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyModerationGetMessageContextMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyModerationGetMessageContextMethod.swift
@@ -38,15 +38,15 @@ extension ATProtoBlueskyChat {
         messagesBefore: Int? = 5,
         messagesAfter: Int? = 5
     ) async throws -> ChatBskyLexicon.Moderation.GetMessageContextOutput {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.moderation.getMessageContext") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.moderation.getMessageContext") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyModerationUpdateActorAccessMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyModerationUpdateActorAccessMethod.swift
@@ -33,15 +33,15 @@ extension ATProtoBlueskyChat {
         doesAllowAccess: Bool,
         reference: String? = nil
     ) async throws {
-        guard let _ = try await self.getUserSession(),
+        guard let session = try await self.getUserSession(),
               let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
 
         let accessToken = try await keychain.retrieveAccessToken()
-//        let sessionURL = session.serviceEndpoint.absoluteString
+        let sessionURL = session.serviceEndpoint.absoluteString
 
-        guard let requestURL = URL(string: "\(APIHostname.bskyChat)/xrpc/chat.bsky.moderation.updateActorAccess") else {
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.moderation.updateActorAccess") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 


### PR DESCRIPTION
## Description
Chat (chat.bsky.*) methods built their request URL from the hardcoded APIHostname.bskyChat and POSTed the user's PDS access token straight to api.bsky.chat. The atproto-proxy header is only honored by a PDS the proxying, so it had no effect when the request never transited the PDS — entryway-hosted accounts happened to work, but accounts on any other PDS were rejected and all DM operations failed.

Fix: in all 22 ChatBsky* methods, bind the active session and build the URL from session.serviceEndpoint (the PDS resolved from the user's DID document) instead of APIHostname.bskyChat, keeping isRelatedToBskyChat: true so the proxy header still forwards to the chat service. This restores the commented-out sessionURL lines and matches every other authenticated method in the library, which already route via session.serviceEndpoint.

No public API changes; behavior is unchanged for entryway-hosted accounts. swift build succeeds with no new warnings.
