### PR TITLE
fix: add auth headers to self-bound wrappers

### DIFF
--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentityGetRecommendedDidCredentialsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentityGetRecommendedDidCredentialsMethod.swift
@@ -27,9 +27,13 @@ extension ATProtoKit {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func getRecommendedDIDCredentials() async throws -> ComAtprotoLexicon.Identity.GetRecommendedDidCredentialsOutput {
-        guard let session = try await self.getUserSession() else {
+        guard let session = try await self.getUserSession(),
+              let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
+
+        try await sessionConfiguration?.ensureValidToken()
+        let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 
         guard let requestURL = URL(string: "\(sessionURL)/xrpc/com.atproto.identity.getRecommendedDidCredentials") else {
@@ -42,7 +46,7 @@ extension ATProtoKit {
                 andMethod: .get,
                 acceptValue: "application/json",
                 contentTypeValue: nil,
-                authorizationValue: nil
+                authorizationValue: "Bearer \(accessToken)"
             )
             let response = try await apiClientService.sendRequest(
                 request, decodeTo:

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentitySubmitPlcOperationMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoIdentitySubmitPlcOperationMethod.swift
@@ -27,9 +27,13 @@ extension ATProtoKit {
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
     /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
     public func submitPLCOperation(_ operation: ComAtprotoLexicon.Identity.SignedPLCOperation) async throws {
-        guard let session = try await self.getUserSession() else {
+        guard let session = try await self.getUserSession(),
+              let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
+
+        try await sessionConfiguration?.ensureValidToken()
+        let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 
         guard let requestURL = URL(string: "\(sessionURL)/xrpc/com.atproto.identity.submitPlcOperation") else {
@@ -45,8 +49,8 @@ extension ATProtoKit {
                 forRequest: requestURL,
                 andMethod: .post,
                 acceptValue: "application/json",
-                contentTypeValue: nil,
-                authorizationValue: nil
+                contentTypeValue: "application/json",
+                authorizationValue: "Bearer \(accessToken)"
             )
             _ = try await apiClientService.sendRequest(
                 request,

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoImportRepoMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoImportRepoMethod.swift
@@ -34,9 +34,13 @@ extension ATProtoKit {
     public func importRepository(
         _ repositoryData: Data
     ) async throws {
-        guard let session = try await self.getUserSession() else {
+        guard let session = try await self.getUserSession(),
+              let keychain = sessionConfiguration?.keychainProtocol else {
             throw ATRequestPrepareError.missingActiveSession
         }
+
+        try await sessionConfiguration?.ensureValidToken()
+        let accessToken = try await keychain.retrieveAccessToken()
         let sessionURL = session.serviceEndpoint.absoluteString
 
         guard let requestURL = URL(string: "\(sessionURL)/xrpc/com.atproto.repo.importRepo") else {
@@ -53,7 +57,7 @@ extension ATProtoKit {
                 andMethod: .post,
                 acceptValue: nil,
                 contentTypeValue: "application/vnd.ipld.car",
-                authorizationValue: nil
+                authorizationValue: "Bearer \(accessToken)"
             )
 
             _ = try await apiClientService.sendRequest(


### PR DESCRIPTION
## Description
Three self-bound wrappers reach the correct PDS (after #287) but are rejected because they pass `authorizationValue: nil`. `submitPLCOperation` additionally passes `contentTypeValue: nil` for a JSON body, so it fails the encoding check before auth is even evaluated.

This PR resolves the keychain alongside the session, refreshes the token via `ensureValidToken()`, and sends `Authorization: Bearer <accessToken>` — the same pattern already used in `activateAccount`. `submitPLCOperation` also gets `Content-Type: application/json` (its lexicon declares `"encoding": "application/json"` on `input`). `importRepository` already sets `application/vnd.ipld.car`, so only the auth header is added there.

| Method | File | Fix |
|---|---|---|
| `submitPLCOperation(_:)` | `ComAtprotoIdentitySubmitPlcOperationMethod.swift` | `authorizationValue`, `contentTypeValue` |
| `getRecommendedDIDCredentials()` | `ComAtprotoIdentityGetRecommendedDidCredentialsMethod.swift` | `authorizationValue` |
| `importRepository(_:)` | `ComAtprotoRepoImportRepoMethod.swift` | `authorizationValue` |

## Linked Issues
#292

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
This change requires no documentation changes.

## Credits
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]