### PR TITLE
Handle third party PDS for video uploads

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyVideoUploadVideoMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyVideoUploadVideoMethod.swift
@@ -36,8 +36,10 @@ extension ATProtoKit {
             throw ATRequestPrepareError.missingActiveSession
         }
 
-        guard let serviceEndpoint = session.didDocument?.service[0].serviceEndpoint,
-              let serviceEndpointHost = serviceEndpoint.hostname() else {
+        // Use the session's resolved service endpoint rather than `didDocument.service[0]`,
+        // which assumes the PDS is the first service entry and is nil on third-party PDS
+        // hosts whose DID document orders services differently or fails to decode.
+        guard let serviceEndpointHost = session.serviceEndpoint.hostname() else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 


### PR DESCRIPTION
Description

  uploadVideo(_:) derived the PDS host from session.didDocument?.service[0].serviceEndpoint, which assumes the
  PDS is the first entry in the DID document's service array. On accounts hosted by third-party PDS
  providers, the DID document may order services differently or fail to decode, leaving didDocument nil — so
  the guard threw ATRequestPrepareError.invalidRequestURL and video uploads (including GIFs posted as video)
  failed.

  This switches the host derivation to session.serviceEndpoint, which SessionConfiguration already resolves
  via checkServiceForATProto() (with a fallback to the configured PDS URL) and is therefore populated reliably
  regardless of DID-document service ordering. For bsky.social-hosted accounts the resolved host is
  unchanged, so their behavior is identical; third-party PDS accounts now resolve correctly. The service-auth
  audience remains did:web:<PDS host>, matching the official client.

  Linked Issues

  N/A

  Type of Change

  - [x] Bug Fix
  - [ ] New Feature
  - [ ] Documentation

  Checklist:

  - [x] My code follows the ATProtoKit API Design Guidelines as well as the Swift API Design Guidelines.
  - [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand
  areas.
  - [ ] I have made corresponding changes to the documentation.
  - [x] My changes generate no new warnings or errors in the compiler or runtime.
  - [x] My code is able to build and run on my machine.

  Additional Notes
  
  getUploadLimits() runs before uploadVideo(_:) in buildVideo and succeeded against video.bsky.app for the
  affected third-party-PDS account, confirming the upload service accepts these accounts — the host-derivation
  guard was the only blocker.
