### PR TITLE
Add AttachmentLexiconLimit and apply lexicon-based attachment size li…

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ListRecord/CreateListRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ListRecord/CreateListRecord.swift
@@ -119,7 +119,8 @@ extension ATProtoBluesky {
                 let postEmbed = try await uploadImages(
                     [listAvatarImage],
                     pdsURL: sessionURL,
-                    accessToken: accessToken
+                    accessToken: accessToken,
+                    maxSize: AttachmentLexiconLimit.listAvatar
                 )
 
                 switch postEmbed {

--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ListRecord/UpdateListRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ListRecord/UpdateListRecord.swift
@@ -118,7 +118,8 @@ extension ATProtoBluesky {
                         let postEmbed = try await uploadImages(
                             [listAvatarImageField],
                             pdsURL: sessionURL,
-                            accessToken: accessToken
+                            accessToken: accessToken,
+                            maxSize: AttachmentLexiconLimit.listAvatar
                         )
 
                         switch postEmbed {

--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
@@ -592,17 +592,22 @@ extension ATProtoBluesky {
     ///   4 images.
     ///   - pdsURL: The URL of the Personal Data Server (PDS). Defaults to `https://bsky.social`.
     ///   - accessToken: The access token used to authenticate to the user.
+    ///   - maxSize: The maximum size (in bytes) each image is allowed to be. Defaults to
+    ///   ``AttachmentLexiconLimit/postImageEmbed`` (2 MB), the limit of the `app.bsky.embed.images`
+    ///   lexicon this method builds. Callers reusing this method for a different lexicon (e.g.,
+    ///   a profile avatar or list avatar) should pass that lexicon's limit instead.
     /// - Returns: An ``AppBskyLexicon/Feed/PostRecord/EmbedUnion``, which contains an array of
     /// ``AppBskyLexicon/Embed/ImagesDefinition``s for use in a record.
     ///
-    /// - Important: Each image can only be 1 MB in size.
+    /// - Important: Each image can only be `maxSize` bytes in size.
     public func uploadImages(_ images: [ATProtoTools.ImageQuery], pdsURL: String = "https://bsky.social",
-                             accessToken: String) async throws -> AppBskyLexicon.Feed.PostRecord.EmbedUnion {
+                             accessToken: String,
+                             maxSize: Int = AttachmentLexiconLimit.postImageEmbed) async throws -> AppBskyLexicon.Feed.PostRecord.EmbedUnion {
         var embedImages = [AppBskyLexicon.Embed.ImagesDefinition.Image]()
 
         for image in images {
             // Check if the image is too large.
-            guard image.imageData.count <= 1_000_000 else {
+            guard image.imageData.count <= maxSize else {
                 throw ATBlueskyError.imageTooLarge
             }
 
@@ -669,8 +674,7 @@ extension ATProtoBluesky {
                            aspectRatio: AppBskyLexicon.Embed.AspectRatioDefinition? = nil, pollingFrequency: Int = 3, pdsURL: String = "https://bsky.social",
                            accessToken: String) async throws -> AppBskyLexicon.Feed.PostRecord.EmbedUnion {
         // Check if the size of the video is small enough.
-        let sizeLimit = 100 * 1024 * 1024 // 100MB in bytes
-        if video.count >= sizeLimit {
+        if video.count >= AttachmentLexiconLimit.videoEmbed {
             throw ATJobStatusError.videoSizeTooLarge(message: "The video file is too large. The maximum file size is currently 100MB.")
         }
 
@@ -774,6 +778,11 @@ extension ATProtoBluesky {
         if let captions = captions {
             print("Beginning caption collection...")
             for caption in captions {
+                // Check if the caption file is too large.
+                guard caption.file.count <= AttachmentLexiconLimit.videoVTTCaption else {
+                    throw ATBlueskyError.captionTooLarge
+                }
+
                 let blobReference = try await atProtoKitInstance.uploadBlob(
                     pdsURL: pdsURL,
                     accessToken: accessToken,
@@ -818,7 +827,7 @@ extension ATProtoBluesky {
         let image: Data? = {
             guard let thumbnailImageURL,
                   let data = try? Data(contentsOf: thumbnailImageURL),
-                  data.count <= 1_000_000 else { return nil }
+                  data.count <= AttachmentLexiconLimit.externalEmbedThumbnail else { return nil }
             return data
         }()
 

--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ProfileRecord/CreateProfileRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ProfileRecord/CreateProfileRecord.swift
@@ -184,7 +184,8 @@ extension ATProtoBluesky {
             let postEmbed = try await uploadImages(
                 [avatarImage],
                 pdsURL: sessionURL,
-                accessToken: accessToken
+                accessToken: accessToken,
+                maxSize: AttachmentLexiconLimit.profileAvatar
             )
 
             switch postEmbed {
@@ -202,7 +203,8 @@ extension ATProtoBluesky {
             let postEmbed = try await uploadImages(
                 [bannerImage],
                 pdsURL: sessionURL,
-                accessToken: accessToken
+                accessToken: accessToken,
+                maxSize: AttachmentLexiconLimit.profileBanner
             )
 
             switch postEmbed {

--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ProfileRecord/UpdateProfileRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/ProfileRecord/UpdateProfileRecord.swift
@@ -127,7 +127,8 @@ extension ATProtoBluesky {
                         let postEmbed = try await uploadImages(
                             [avatarImageField],
                             pdsURL: sessionURL,
-                            accessToken: accessToken
+                            accessToken: accessToken,
+                            maxSize: AttachmentLexiconLimit.profileAvatar
                         )
 
                         switch postEmbed {
@@ -149,7 +150,8 @@ extension ATProtoBluesky {
                         let postEmbed = try await uploadImages(
                             [bannerImageField],
                             pdsURL: sessionURL,
-                            accessToken: accessToken
+                            accessToken: accessToken,
+                            maxSize: AttachmentLexiconLimit.profileBanner
                         )
 
                         switch postEmbed {

--- a/Sources/ATProtoKit/Errors/ATProtoError.swift
+++ b/Sources/ATProtoKit/Errors/ATProtoError.swift
@@ -116,6 +116,9 @@ extension ATProtoBluesky {
 
         /// The image used is too large.
         case imageTooLarge
+
+        /// The video caption (.vtt) file is too large.
+        case captionTooLarge
     }
 }
 

--- a/Sources/ATProtoKit/Utilities/AttachmentLexiconLimit.swift
+++ b/Sources/ATProtoKit/Utilities/AttachmentLexiconLimit.swift
@@ -1,0 +1,83 @@
+//
+//  AttachmentLexiconLimit.swift
+//
+//
+//  Created by Christopher Jr Riley on 2026-06-27.
+//
+
+import Foundation
+
+/// The maximum blob sizes (in bytes) for post attachments, as declared by their
+/// respective lexicons.
+///
+/// Each value mirrors the `maxSize` constraint of the lexicon that governs the attachment.
+/// Routing every size guard through this type keeps the limits in a single place, so a future
+/// lexicon relaxation is a one-line change instead of a hunt for inlined magic numbers.
+public enum AttachmentLexiconLimit {
+
+    /// The maximum size of a post image embed: 2,000,000 bytes.
+    ///
+    /// Declared by `app.bsky.embed.images` at `defs.image.properties.image.maxSize`.
+    ///
+    /// - SeeAlso: [`app.bsky.embed.images`][images] lexicon.
+    ///
+    /// [images]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/images.json
+    public static let postImageEmbed = 2_000_000
+
+    /// The maximum size of an external link thumbnail: 1,000,000 bytes.
+    ///
+    /// Declared by `app.bsky.embed.external` at `defs.external.properties.thumb.maxSize`.
+    ///
+    /// - SeeAlso: [`app.bsky.embed.external`][external] lexicon.
+    ///
+    /// [external]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/external.json
+    public static let externalEmbedThumbnail = 1_000_000
+
+    /// The maximum size of a profile avatar: 1,000,000 bytes.
+    ///
+    /// Declared by `app.bsky.actor.profile` at `defs.main.record.properties.avatar.maxSize`.
+    ///
+    /// - SeeAlso: [`app.bsky.actor.profile`][profile] lexicon.
+    ///
+    /// [profile]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/actor/profile.json
+    public static let profileAvatar = 1_000_000
+
+    /// The maximum size of a profile banner: 1,000,000 bytes.
+    ///
+    /// Declared by `app.bsky.actor.profile` at `defs.main.record.properties.banner.maxSize`.
+    ///
+    /// - SeeAlso: [`app.bsky.actor.profile`][profile] lexicon.
+    ///
+    /// [profile]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/actor/profile.json
+    public static let profileBanner = 1_000_000
+
+    /// The maximum size of a list avatar: 1,000,000 bytes.
+    ///
+    /// Declared by `app.bsky.graph.list` at `defs.main.record.properties.avatar.maxSize`.
+    ///
+    /// - SeeAlso: [`app.bsky.graph.list`][list] lexicon.
+    ///
+    /// [list]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/graph/list.json
+    public static let listAvatar = 1_000_000
+
+    /// The maximum size of a video embed: 100,000,000 bytes.
+    ///
+    /// Declared by `app.bsky.embed.video` at `defs.main.properties.video.maxSize`.
+    ///
+    /// - SeeAlso: [`app.bsky.embed.video`][video] lexicon.
+    ///
+    /// [video]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/video.json
+    public static let videoEmbed = 100_000_000
+
+    /// The maximum size of a video VTT caption file: 20,000 bytes.
+    ///
+    /// Declared by `app.bsky.embed.video` at `defs.caption.properties.file.maxSize`.
+    ///
+    /// - SeeAlso: [`app.bsky.embed.video`][video] lexicon.
+    ///
+    /// [video]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/video.json
+    public static let videoVTTCaption = 20_000
+
+    // The daily video upload quota is server-driven via `app.bsky.video.getUploadLimits`
+    // and is therefore not represented here.
+}


### PR DESCRIPTION
## Description
`ATProtoBluesky`'s record-creation paths inlined blob `maxSize` guards as magic numbers, and several drifted from their lexicons. This PR adds `AttachmentLexiconLimit` — a `public enum` whose constants mirror each lexicon's `maxSize` — and routes every guard through it, so future lexicon bumps are a one-line change.

Corrections:
- Post image embed: `1_000_000` → `2_000_000` (`app.bsky.embed.images` raised the limit from 1 MB to 2 MB).
- Video embed: `100 * 1024 * 1024` → `100_000_000`, matching the lexicon literal.
- Video VTT caption: now guarded (20,000 bytes) via a new `ATBlueskyError.captionTooLarge`, instead of failing server-side.
- External thumbnail and profile/list avatars/banners are left at 1,000,000 but routed through the new constants.

API change: `uploadImages(_:pdsURL:accessToken:)` gains one new parameter, `maxSize: Int = AttachmentLexiconLimit.postImageEmbed`. It defaults to the post-image limit, and lets callers reusing the helper (e.g. profile/list avatars) pass their own lexicon's limit. This is a source-compatible, non-breaking addition.

## Linked Issues
#269

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
Values are taken from the upstream lexicon JSON. For the video case, community discussion (e.g. social-app #8384) suggests the server may enforce a different limit than the lexicon literal — `videoEmbed` uses the lexicon value `100_000_000` and can be adjusted if needed. Please correct any value I may have misread before merging.

## Credits
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
