### PR TITLE
Add create-side support for app.bsky.embed.gallery

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
@@ -429,6 +429,12 @@ extension ATProtoBluesky {
                                 pdsURL: sessionURL,
                                 accessToken: accessToken
                             )
+                        case .gallery(let images):
+                            resolvedEmbed = try await uploadGallery(
+                                images,
+                                pdsURL: sessionURL,
+                                accessToken: accessToken
+                            )
                         case .external(let url, let title, let description, let thumbnailImageURL):
                             resolvedEmbed = await buildExternalEmbed(
                                 from: url,
@@ -628,6 +634,49 @@ extension ATProtoBluesky {
         }
 
         return .images(AppBskyLexicon.Embed.ImagesDefinition(images: embedImages))
+    }
+
+    /// Uploads images to the AT Protocol as a gallery for attaching to a record at a later request.
+    ///
+    /// `app.bsky.embed.gallery` is the successor to `app.bsky.embed.images`, supporting a larger
+    /// number of images per post.
+    ///
+    /// - Parameters:
+    ///   - images: The ``ATProtoTools/ImageQuery`` that contains the image data. The schema-level
+    ///   maximum is 20 images; clients should enforce a soft limit of 10 items in authoring UIs.
+    ///   - pdsURL: The URL of the Personal Data Server (PDS). Defaults to `https://bsky.social`.
+    ///   - accessToken: The access token used to authenticate to the user.
+    /// - Returns: An ``AppBskyLexicon/Feed/PostRecord/EmbedUnion``, which contains an
+    /// ``AppBskyLexicon/Embed/GalleryDefinition`` for use in a record.
+    ///
+    /// - Important: Each image can only be 2 MB in size.
+    public func uploadGallery(_ images: [ATProtoTools.ImageQuery], pdsURL: String = "https://bsky.social",
+                              accessToken: String) async throws -> AppBskyLexicon.Feed.PostRecord.EmbedUnion {
+        var items = [AppBskyLexicon.Embed.GalleryDefinition.ItemUnion]()
+
+        for image in images {
+            // Check if the image is too large.
+            guard image.imageData.count <= AttachmentLexiconLimit.galleryImageEmbed else {
+                throw ATBlueskyError.imageTooLarge
+            }
+
+            // Upload the image, then get the server response.
+            let blobReference = try await ATProtoKit(canUseBlueskyRecords: false).uploadBlob(
+                pdsURL: pdsURL,
+                accessToken: accessToken,
+                filename: image.fileName,
+                imageData: image.imageData
+            )
+
+            let galleryImage = AppBskyLexicon.Embed.GalleryDefinition.Image(
+                imageBlob: blobReference,
+                altText: image.altText ?? "",
+                aspectRatio: image.aspectRatio
+            )
+            items.append(.itemImage(galleryImage))
+        }
+
+        return .gallery(AppBskyLexicon.Embed.GalleryDefinition(items: items))
     }
 
     /// A structure that contains closed captioning information.
@@ -909,6 +958,15 @@ extension ATProtoBluesky {
         ///   - altText: The alt text for the video. Optional.
         ///   - aspectRatio: The aspect ratio of the video. Optional.
         case video(video: Data, captions: [Caption]? = nil, altText: String? = nil, aspectoRatio: AppBskyLexicon.Embed.AspectRatioDefinition? = nil)
+
+        /// Represents a set of images to be embedded as a gallery in the post.
+        ///
+        /// `app.bsky.embed.gallery` is the successor to `images`, supporting a larger number of
+        /// images per post.
+        ///
+        /// - Parameter images: An array of ``ATProtoTools/ImageQuery`` objects, each containing
+        /// the image data, metadata, and filenames of the image.
+        case gallery(images: [ATProtoTools.ImageQuery])
 
         /// Represents an external link to be embedded in the post.
         ///

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedRecordWithMedia.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedRecordWithMedia.swift
@@ -71,6 +71,9 @@ extension AppBskyLexicon.Embed {
             /// A video that will be embedded.
             case embedVideo(AppBskyLexicon.Embed.VideoDefinition)
 
+            /// A gallery that will be embedded.
+            case embedGallery(AppBskyLexicon.Embed.GalleryDefinition)
+
             /// An unknown case.
             case unknown(String, [String: CodableValue])
 
@@ -85,6 +88,8 @@ extension AppBskyLexicon.Embed {
                         self = .embedVideo(try AppBskyLexicon.Embed.VideoDefinition(from: decoder))
                     case "app.bsky.embed.external":
                         self = .embedExternal(try AppBskyLexicon.Embed.ExternalDefinition(from: decoder))
+                    case "app.bsky.embed.gallery":
+                        self = .embedGallery(try AppBskyLexicon.Embed.GalleryDefinition(from: decoder))
                     default:
                         let singleValueDecodingContainer = try decoder.singleValueContainer()
                         let dictionary = try Self.decodeDictionary(from: singleValueDecodingContainer, decoder: decoder)
@@ -102,6 +107,8 @@ extension AppBskyLexicon.Embed {
                     case .embedExternal(let media):
                         try container.encode(media)
                     case .embedVideo(let value):
+                        try container.encode(value)
+                    case .embedGallery(let value):
                         try container.encode(value)
                     default:
                         break

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedPost.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedPost.swift
@@ -181,6 +181,9 @@ extension AppBskyLexicon.Feed {
             /// A video embed.
             case video(AppBskyLexicon.Embed.VideoDefinition)
 
+            /// A gallery embed.
+            case gallery(AppBskyLexicon.Embed.GalleryDefinition)
+
             /// An external embed.
             case external(AppBskyLexicon.Embed.ExternalDefinition)
 
@@ -202,6 +205,8 @@ extension AppBskyLexicon.Feed {
                         self = .images(try AppBskyLexicon.Embed.ImagesDefinition(from: decoder))
                     case "app.bsky.embed.video":
                         self = .video(try AppBskyLexicon.Embed.VideoDefinition(from: decoder))
+                    case "app.bsky.embed.gallery":
+                        self = .gallery(try AppBskyLexicon.Embed.GalleryDefinition(from: decoder))
                     case "app.bsky.embed.external":
                         self = .external(try AppBskyLexicon.Embed.ExternalDefinition(from: decoder))
                     case "app.bsky.embed.record":
@@ -226,6 +231,9 @@ extension AppBskyLexicon.Feed {
                     case .video(let value):
                         try container.encode("app.bsky.embed.video", forKey: .type)
                         try value.encode(to: encoder)
+                    case .gallery(let galleryValue):
+                        try container.encode("app.bsky.embed.gallery", forKey: .type)
+                        try galleryValue.encode(to: encoder)
                     case .external(let externalValue):
                         try container.encode("app.bsky.embed.external", forKey: .type)
                         try externalValue.encode(to: encoder)

--- a/Sources/ATProtoKit/Utilities/AttachmentLexiconLimit.swift
+++ b/Sources/ATProtoKit/Utilities/AttachmentLexiconLimit.swift
@@ -24,6 +24,15 @@ public enum AttachmentLexiconLimit {
     /// [images]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/images.json
     public static let postImageEmbed = 2_000_000
 
+    /// The maximum size of a gallery image embed: 2,000,000 bytes.
+    ///
+    /// Declared by `app.bsky.embed.gallery` at `defs.image.properties.image.maxSize`.
+    ///
+    /// - SeeAlso: [`app.bsky.embed.gallery`][gallery] lexicon.
+    ///
+    /// [gallery]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/gallery.json
+    public static let galleryImageEmbed = 2_000_000
+
     /// The maximum size of an external link thumbnail: 1,000,000 bytes.
     ///
     /// Declared by `app.bsky.embed.external` at `defs.external.properties.thumb.maxSize`.


### PR DESCRIPTION
## Description
Adds create-side (authoring) support for `app.bsky.embed.gallery`, the successor to
`app.bsky.embed.images` that allows more than four images per post.

Until now, gallery embeds could be decoded and displayed (`GalleryDefinition` and the
view-side `RecordWithMediaDefinition.View.MediaUnion` already exposed `embedGalleryView`),
but they could not be authored through the typed post-creation pipeline:
`PostRecord.EmbedUnion` and the record-side `RecordWithMediaDefinition.MediaUnion` had no
gallery case, and `EmbedIdentifier` offered no gallery option — so a hand-built gallery
embed was silently dropped by the encoder's `default` arm. Clients had to bypass the typed
pipeline entirely and call `com.atproto.repo.createRecord` with raw JSON.

This PR closes that gap. All changes are additive:

- **`AppBskyLexicon.Feed.PostRecord.EmbedUnion`** — adds `case gallery(GalleryDefinition)`
  with matching `"app.bsky.embed.gallery"` branches in `init(from:)` and `encode(to:)`.
- **`AppBskyLexicon.Embed.RecordWithMediaDefinition.MediaUnion` (record side)** — adds
  `case embedGallery(GalleryDefinition)` with matching coding arms, closing the asymmetry
  with the view-side `MediaUnion` that already had `embedGalleryView`.
- **`ATProtoBluesky.EmbedIdentifier`** — adds `case gallery(images: [ATProtoTools.ImageQuery])`.
- **`ATProtoBluesky.uploadGallery(_:pdsURL:accessToken:)`** — new helper parallel to
  `uploadImages`, returning a `PostRecord.EmbedUnion`. It uploads each blob and builds a
  `GalleryDefinition`.
- **`createPostRecord`** — adds a `.gallery` arm to the embed switch that calls `uploadGallery`.
- **`AttachmentLexiconLimit`** — adds `galleryImageEmbed` (2,000,000 bytes), the gallery
  per-image blob limit declared by the lexicon, used by `uploadGallery`.

No new model types were required; `GalleryDefinition` and its nested types already exist.
This is not a breaking change.

## Linked Issues
#270

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
- `app.bsky.embed.gallery#image` requires `aspectRatio` (unlike `app.bsky.embed.images#image`,
  where it is optional). Callers must populate `ImageQuery.aspectRatio`; otherwise the PDS
  rejects the record with `InvalidRequest: Missing required key "aspectRatio"`. The model
  keeps `aspectRatio` optional, so enforcement is currently the caller's responsibility —
  happy to tighten this (non-optional, or a pre-encode guard) if preferred.
- The gallery schema allows up to 20 items, but `GalleryDefinition.encode(to:)` already
  truncates to a soft cap of 10 (matching the official client's authoring limit), so
  `uploadGallery` follows the same effective cap.

## Credits
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
