### PR TITLE
Fix getPreferences() decode: tolerate null and add missing preference cases

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
@@ -815,11 +815,11 @@ extension AppBskyLexicon.Actor {
 
         /// An unknown case.
         ///
-        /// The payload uses `[String: CodableValue?]` so JSON `null` field values inside
-        /// third-party preference types (e.g. `skyfeedBuilderFeedsPref`) don't fail the decode.
-        /// `CodableValue` itself has no `null` representation, so null fields surface as `nil`
-        /// values in this dictionary.
-        case unknown(String, [String: CodableValue?])
+        /// JSON `null` field values inside third-party preference types (e.g.
+        /// `skyfeedBuilderFeedsPref`) are tolerated during decode: nested `null`s are handled by
+        /// `CodableValue` itself, and any top-level `null` field is dropped. `CodableValue` has no
+        /// `null` representation, so the payload type stays `[String: CodableValue]`.
+        case unknown(String, [String: CodableValue])
 
         // Implement custom decoding
         public init(from decoder: Decoder) throws {
@@ -861,9 +861,12 @@ extension AppBskyLexicon.Actor {
                     self = .liveEventPreferences(try AppBskyLexicon.Actor.LiveEventPreferencesDefinition(from: decoder))
                 default:
                     let singleValueDecodingContainer = try decoder.singleValueContainer()
+                    // Decode through `[String: CodableValue?]` to tolerate a top-level JSON `null`
+                    // field, then drop those entries so the public payload stays
+                    // `[String: CodableValue]`. Nested `null`s are handled within `CodableValue`.
                     let dictionary = try singleValueDecodingContainer.decode([String: CodableValue?].self)
 
-                    self = .unknown(type ?? "unknown", dictionary)
+                    self = .unknown(type ?? "unknown", dictionary.compactMapValues { $0 })
             }
         }
 

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
@@ -814,11 +814,6 @@ extension AppBskyLexicon.Actor {
         case liveEventPreferences(AppBskyLexicon.Actor.LiveEventPreferencesDefinition)
 
         /// An unknown case.
-        ///
-        /// JSON `null` field values inside third-party preference types (e.g.
-        /// `skyfeedBuilderFeedsPref`) are tolerated during decode: nested `null`s are handled by
-        /// `CodableValue` itself, and any top-level `null` field is dropped. `CodableValue` has no
-        /// `null` representation, so the payload type stays `[String: CodableValue]`.
         case unknown(String, [String: CodableValue])
 
         // Implement custom decoding
@@ -861,12 +856,9 @@ extension AppBskyLexicon.Actor {
                     self = .liveEventPreferences(try AppBskyLexicon.Actor.LiveEventPreferencesDefinition(from: decoder))
                 default:
                     let singleValueDecodingContainer = try decoder.singleValueContainer()
-                    // Decode through `[String: CodableValue?]` to tolerate a top-level JSON `null`
-                    // field, then drop those entries so the public payload stays
-                    // `[String: CodableValue]`. Nested `null`s are handled within `CodableValue`.
-                    let dictionary = try singleValueDecodingContainer.decode([String: CodableValue?].self)
+                    let dictionary = try singleValueDecodingContainer.decode([String: CodableValue].self)
 
-                    self = .unknown(type ?? "unknown", dictionary.compactMapValues { $0 })
+                    self = .unknown(type ?? "unknown", dictionary)
             }
         }
 

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
@@ -804,8 +804,22 @@ extension AppBskyLexicon.Actor {
         /// The "Verification Visibility" preference.
         case verificationPreference(AppBskyLexicon.Actor.VerificationPreferenceDefinition)
 
+        /// The "Declared Age" preference.
+        ///
+        /// Read-only preference exposing age flags inferred by the server from the user's
+        /// declared birth date.
+        case declaredAge(AppBskyLexicon.Actor.DeclaredAgePreferenceDefinition)
+
+        /// The "Live Event" preferences.
+        case liveEventPreferences(AppBskyLexicon.Actor.LiveEventPreferencesDefinition)
+
         /// An unknown case.
-        case unknown(String, [String: CodableValue])
+        ///
+        /// The payload uses `[String: CodableValue?]` so JSON `null` field values inside
+        /// third-party preference types (e.g. `skyfeedBuilderFeedsPref`) don't fail the decode.
+        /// `CodableValue` itself has no `null` representation, so null fields surface as `nil`
+        /// values in this dictionary.
+        case unknown(String, [String: CodableValue?])
 
         // Implement custom decoding
         public init(from decoder: Decoder) throws {
@@ -841,9 +855,13 @@ extension AppBskyLexicon.Actor {
                     self = .postInteractionSettingsPreference(try AppBskyLexicon.Actor.PostInteractionSettingsPreferenceDefinition(from: decoder))
                 case "app.bsky.actor.defs#verificationPrefs":
                     self = .verificationPreference(try AppBskyLexicon.Actor.VerificationPreferenceDefinition(from: decoder))
+                case "app.bsky.actor.defs#declaredAgePref":
+                    self = .declaredAge(try AppBskyLexicon.Actor.DeclaredAgePreferenceDefinition(from: decoder))
+                case "app.bsky.actor.defs#liveEventPreferences":
+                    self = .liveEventPreferences(try AppBskyLexicon.Actor.LiveEventPreferencesDefinition(from: decoder))
                 default:
                     let singleValueDecodingContainer = try decoder.singleValueContainer()
-                    let dictionary = try Self.decodeDictionary(from: singleValueDecodingContainer, decoder: decoder)
+                    let dictionary = try singleValueDecodingContainer.decode([String: CodableValue?].self)
 
                     self = .unknown(type ?? "unknown", dictionary)
             }
@@ -895,6 +913,12 @@ extension AppBskyLexicon.Actor {
                     try value.encode(to: encoder)
                 case .verificationPreference(let value):
                     try container.encode("app.bsky.actor.defs#verificationPrefs", forKey: .type)
+                    try value.encode(to: encoder)
+                case .declaredAge(let value):
+                    try container.encode("app.bsky.actor.defs#declaredAgePref", forKey: .type)
+                    try value.encode(to: encoder)
+                case .liveEventPreferences(let value):
+                    try container.encode("app.bsky.actor.defs#liveEventPreferences", forKey: .type)
                     try value.encode(to: encoder)
                 default:
                     break
@@ -2260,6 +2284,122 @@ extension AppBskyLexicon.Actor {
             enum CodingKeys: String, CodingKey {
                 case type = "$type"
             }
+        }
+    }
+
+    /// A definition model for a "Declared Age" preference.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Read-only preference containing
+    /// value(s) inferred from the user's declared birthdate. Absence of this preference object in
+    /// the response indicates that the user has not made a declaration."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.actor.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/actor/defs.json
+    public struct DeclaredAgePreferenceDefinition: Sendable, Codable {
+
+        /// The identifier of the lexicon.
+        ///
+        /// - Warning: The value must not change.
+        public let type: String = "app.bsky.actor.defs#declaredAgePref"
+
+        /// Indicates whether the user has declared that they are over 13 years of age. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Indicates if the user has declared
+        /// that they are over 13 years of age."
+        public let isOverAge13: Bool?
+
+        /// Indicates whether the user has declared that they are over 16 years of age. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Indicates if the user has declared
+        /// that they are over 16 years of age."
+        public let isOverAge16: Bool?
+
+        /// Indicates whether the user has declared that they are over 18 years of age. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Indicates if the user has declared
+        /// that they are over 18 years of age."
+        public let isOverAge18: Bool?
+
+        public init(isOverAge13: Bool? = nil, isOverAge16: Bool? = nil, isOverAge18: Bool? = nil) {
+            self.isOverAge13 = isOverAge13
+            self.isOverAge16 = isOverAge16
+            self.isOverAge18 = isOverAge18
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.isOverAge13 = try container.decodeIfPresent(Bool.self, forKey: .isOverAge13)
+            self.isOverAge16 = try container.decodeIfPresent(Bool.self, forKey: .isOverAge16)
+            self.isOverAge18 = try container.decodeIfPresent(Bool.self, forKey: .isOverAge18)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encodeIfPresent(self.isOverAge13, forKey: .isOverAge13)
+            try container.encodeIfPresent(self.isOverAge16, forKey: .isOverAge16)
+            try container.encodeIfPresent(self.isOverAge18, forKey: .isOverAge18)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case type = "$type"
+            case isOverAge13
+            case isOverAge16
+            case isOverAge18
+        }
+    }
+
+    /// A definition model for a "Live Event" preferences.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Preferences for live events."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.actor.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/actor/defs.json
+    public struct LiveEventPreferencesDefinition: Sendable, Codable {
+
+        /// The identifier of the lexicon.
+        ///
+        /// - Warning: The value must not change.
+        public let type: String = "app.bsky.actor.defs#liveEventPreferences"
+
+        /// An array of feed identifiers that the user has hidden from live events. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "A list of feed IDs that the user
+        /// has hidden from live events."
+        public let hiddenFeedIDs: [String]?
+
+        /// Indicates whether all feeds should be hidden from live events. Optional. Defaults to `false`.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Whether to hide all feeds from
+        /// live events."
+        public let hideAllFeeds: Bool?
+
+        public init(hiddenFeedIDs: [String]? = nil, hideAllFeeds: Bool? = nil) {
+            self.hiddenFeedIDs = hiddenFeedIDs
+            self.hideAllFeeds = hideAllFeeds
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.hiddenFeedIDs = try container.decodeIfPresent([String].self, forKey: .hiddenFeedIDs)
+            self.hideAllFeeds = try container.decodeIfPresent(Bool.self, forKey: .hideAllFeeds)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encodeIfPresent(self.hiddenFeedIDs, forKey: .hiddenFeedIDs)
+            try container.encodeIfPresent(self.hideAllFeeds, forKey: .hideAllFeeds)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case type = "$type"
+            case hiddenFeedIDs = "hiddenFeedIds"
+            case hideAllFeeds
         }
     }
 

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -561,10 +561,15 @@ public enum CodableValue: Codable, Sendable, Equatable, Hashable {
     /// Stores a `Dictionary` with `String` keys and `CodableValue` values.
     case dictionary([String: CodableValue])
 
+    /// Stores a JSON `null` value.
+    case null
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
-        if let value = try? container.decode(Bool.self) {
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
             self = .bool(value)
         } else if let value = try? container.decode(Int.self) {
             self = .int(value)
@@ -572,17 +577,10 @@ public enum CodableValue: Codable, Sendable, Equatable, Hashable {
             self = .double(value)
         } else if let value = try? container.decode(String.self) {
             self = .string(value)
-        } else if let value = try? container.decode([CodableValue?].self) {
-            // Tolerate JSON `null` array elements by decoding through `Optional<CodableValue>`.
-            // `CodableValue` has no `null` representation, so null elements are intentionally
-            // dropped via `compactMap`. The `.array` payload stays `[CodableValue]` (non-Optional).
-            self = .array(value.compactMap { $0 })
-        } else if let value = try? container.decode([String: CodableValue?].self) {
-            // Tolerate JSON `null` field values inside a nested dictionary. `CodableValue` has no
-            // `null` representation, so null entries are intentionally dropped via
-            // `compactMapValues`. The `.dictionary` payload stays `[String: CodableValue]`
-            // (non-Optional).
-            self = .dictionary(value.compactMapValues { $0 })
+        } else if let value = try? container.decode([CodableValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: CodableValue].self) {
+            self = .dictionary(value)
         } else {
             throw DecodingError.typeMismatch(
                 CodableValue.self,
@@ -608,6 +606,8 @@ public enum CodableValue: Codable, Sendable, Equatable, Hashable {
                 try container.encode(value)
             case .dictionary(let value):
                 try container.encode(value)
+            case .null:
+                try container.encodeNil()
         }
     }
 }

--- a/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
+++ b/Sources/ATProtoKit/Utilities/ATRecordProtocol.swift
@@ -572,10 +572,17 @@ public enum CodableValue: Codable, Sendable, Equatable, Hashable {
             self = .double(value)
         } else if let value = try? container.decode(String.self) {
             self = .string(value)
-        } else if let value = try? container.decode([CodableValue].self) {
-            self = .array(value)
-        } else if let value = try? container.decode([String: CodableValue].self) {
-            self = .dictionary(value)
+        } else if let value = try? container.decode([CodableValue?].self) {
+            // Tolerate JSON `null` array elements by decoding through `Optional<CodableValue>`.
+            // `CodableValue` has no `null` representation, so null elements are intentionally
+            // dropped via `compactMap`. The `.array` payload stays `[CodableValue]` (non-Optional).
+            self = .array(value.compactMap { $0 })
+        } else if let value = try? container.decode([String: CodableValue?].self) {
+            // Tolerate JSON `null` field values inside a nested dictionary. `CodableValue` has no
+            // `null` representation, so null entries are intentionally dropped via
+            // `compactMapValues`. The `.dictionary` payload stays `[String: CodableValue]`
+            // (non-Optional).
+            self = .dictionary(value.compactMapValues { $0 })
         } else {
             throw DecodingError.typeMismatch(
                 CodableValue.self,


### PR DESCRIPTION
## Description
Fixes two decoding problems with `app.bsky.actor.defs#preferences`.

1. **`declaredAgePref` / `liveEventPreferences` decode as `.unknown`.** Both are defined in the upstream lexicon but had no corresponding case in `PreferenceUnion`, so they silently fell into `.unknown`, losing typed access to `isOverAge13/16/18` and `hiddenFeedIds` / `hideAllFeeds`. This adds `DeclaredAgePreferenceDefinition` / `LiveEventPreferencesDefinition` plus the matching `$type` arms in `init(from:)` / `encode(to:)` so they decode through typed cases.

2. **A third-party `$type` with nested `null` throws the whole `getPreferences()`.** `CodableValue` has no `null` representation, so a `null` nested inside an unknown `$type` (e.g. Skyfeed's `skyfeedBuilderFeedsPref` at `feeds[].feed.blocks[].value: null`) propagated a `DecodingError.typeMismatch` and failed the entire `[PreferenceUnion]` decode — not just that one entry. `CodableValue.init(from:)` now decodes arrays/dictionaries through `[CodableValue?]` / `[String: CodableValue?]` and drops the `null` elements.

**Non-breaking:** neither `CodableValue`'s public case list nor `PreferenceUnion.unknown`'s associated value type (`[String: CodableValue]`) changes. `Optional<CodableValue>` is only a transient decode trick. `null` values are dropped, but only within unknown-type fields.

## Linked Issues
#298

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
The `CodableValue` change here is open to discussion: it handles `null` by dropping it during decode rather than representing it, since `CodableValue` has no `null` case. How `CodableValue` should represent `nil` values inside `.array` / `.dictionary` is a broader design question — happy to take a different direction (e.g. adding a `null` case) if preferred.

Verified in production against an account with `skyfeedBuilderFeedsPref` (nested `value: null`): all 38 preferences decode (2 fall through to `.unknown`), versus a full `getPreferences()` throw before the fix.

## Credits
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
