### PR TITLE
fix: Decode URI in lexicon "app.bsky.embed.external#external" as String

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
@@ -905,7 +905,7 @@ extension ATProtoBluesky {
 
         let embedExternal = AppBskyLexicon.Embed.ExternalDefinition(
             external: AppBskyLexicon.Embed.ExternalDefinition.External(
-                uri: url,
+                uri: url.absoluteString,
                 title: title,
                 description: description ?? "",
                 thumbnailImage: thumbnailImage ?? nil

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedExternal.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedExternal.swift
@@ -64,7 +64,7 @@ extension AppBskyLexicon.Embed {
             public let type: String = "app.bsky.embed.external#external"
 
             /// The URI of the external content.
-            public let uri: URL
+            public let uri: String
 
             /// The title of the external content.
             public let title: String
@@ -85,7 +85,7 @@ extension AppBskyLexicon.Embed {
             public let associatedRefs: [ComAtprotoLexicon.Repository.StrongReference]?
 
             public init(
-                uri: URL,
+                uri: String,
                 title: String,
                 description: String,
                 thumbnailImage: ComAtprotoLexicon.Repository.UploadBlobOutput?,
@@ -100,7 +100,7 @@ extension AppBskyLexicon.Embed {
 
             public init(from decoder: any Decoder) throws {
                 let container = try decoder.container(keyedBy: CodingKeys.self)
-                self.uri = try container.decode(URL.self, forKey: CodingKeys.uri)
+                self.uri = try container.decode(String.self, forKey: CodingKeys.uri)
                 self.title = try container.decode(String.self, forKey: CodingKeys.title)
                 self.description = try container.decode(String.self, forKey: CodingKeys.description)
                 self.thumbnailImage = try container.decodeIfPresent(ComAtprotoLexicon.Repository.UploadBlobOutput.self, forKey: CodingKeys.thumbnailImage)


### PR DESCRIPTION
Resolves timeline feed decoding failure when external record has invalid characters in the URI. Decoding to String is consistent with all other ATProtoKit URI decoding.

## Description
Describe in detail what this Pull Request does and why it’s needed. Include anything the reviewers need to be aware of.

## Linked Issues
Link any related issues here. Format: `#[issue number]`
#307 

## Type of Change
- [X] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [X] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [X] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings or errors in the compiler or runtime.
- [X] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
