### PR TITLE
fix: correct request body JSON keys to match lexicons

### DIFF
--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteAccountAsAdmin.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/DeleteAccountAsAdmin.swift
@@ -43,7 +43,7 @@ extension ATProtoAdmin {
         }
 
         let requestBody = ComAtprotoLexicon.Admin.DeleteAccountRequestBody(
-            accountDID: accountDID
+            did: accountDID
         )
 
         do {

--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComStprotoServerDeleteAccountMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComStprotoServerDeleteAccountMethod.swift
@@ -49,8 +49,8 @@ extension ATProtoKit {
         }
 
         let requestBody = ComAtprotoLexicon.Server.DeleteAccountRequestBody(
-            accountDID: did,
-            accountPassword: password,
+            did: did,
+            password: password,
             token: deletionToken
         )
 

--- a/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Convo/ChatBskyConvoDeleteMessageForSelf.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Convo/ChatBskyConvoDeleteMessageForSelf.swift
@@ -26,7 +26,7 @@ extension ChatBskyLexicon.Conversation {
         public let messageID: String
 
         enum CodingKeys: String, CodingKey {
-            case conversationID = "convoID"
+            case conversationID = "convoId"
             case messageID = "messageId"
         }
     }

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Admin/ComAtprotoAdminDeleteAccount.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Admin/ComAtprotoAdminDeleteAccount.swift
@@ -23,10 +23,6 @@ extension ComAtprotoLexicon.Admin {
     public struct DeleteAccountRequestBody: Sendable, Codable {
 
         /// The decentralized identifier (DID) of the account to be deleted.
-        public let accountDID: String
-
-        enum CodingKeys: String, CodingKey {
-            case accountDID = "did"
-        }
+        public let did: String
     }
 }

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Admin/ComAtprotoAdminDeleteAccount.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Admin/ComAtprotoAdminDeleteAccount.swift
@@ -24,5 +24,9 @@ extension ComAtprotoLexicon.Admin {
 
         /// The decentralized identifier (DID) of the account to be deleted.
         public let accountDID: String
+
+        enum CodingKeys: String, CodingKey {
+            case accountDID = "did"
+        }
     }
 }

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerDeleteAccount.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerDeleteAccount.swift
@@ -23,20 +23,14 @@ extension ComAtprotoLexicon.Server {
     public struct DeleteAccountRequestBody: Sendable, Codable {
 
         /// The decentralized identifier (DID) of the account.
-        public let accountDID: String
+        public let did: String
 
         /// The main password of the account.
         ///
         /// - Note: This is not the App Password.
-        public let accountPassword: String
+        public let password: String
 
         /// The deletion token used to finalize the process of deleting the account.
         public let token: String
-
-        enum CodingKeys: String, CodingKey {
-            case accountDID = "did"
-            case accountPassword = "password"
-            case token
-        }
     }
 }

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerDeleteAccount.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerDeleteAccount.swift
@@ -32,5 +32,11 @@ extension ComAtprotoLexicon.Server {
 
         /// The deletion token used to finalize the process of deleting the account.
         public let token: String
+
+        enum CodingKeys: String, CodingKey {
+            case accountDID = "did"
+            case accountPassword = "password"
+            case token
+        }
     }
 }


### PR DESCRIPTION
## Description
Account-deletion request bodies used prettified property names (`accountDID` / `accountPassword`) with no `CodingKeys`, so they were serialized under the wrong JSON keys and the server rejected the request. Per the maintainer's guidance in #313, this renames the properties to match the lexicon keys instead of adding `CodingKeys`:

- `com.atproto.server.deleteAccount`: `accountDID` → `did`, `accountPassword` → `password`
- `com.atproto.admin.deleteAccount`: `accountDID` → `did`
- `chat.bsky.convo.deleteMessageForSelf`: fix `CodingKeys` typo `"convoID"` → `"convoId"`

Call sites are updated; public method signatures are unchanged.

## Linked Issues
#313

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
Verified against a live server via a downstream app:
- `com.atproto.server.deleteAccount` — an invalid deletion token now returns `AuthenticationRequired` ("Invalid did or password"), confirming `did` / `password` / `token` are parsed.
- `chat.bsky.convo.deleteMessageForSelf` — a nonexistent conversation returns `InvalidRequest` ("Convo not found"), confirming `convoId` is parsed.
- `com.atproto.admin.deleteAccount` — not verified at runtime (admin-only; a normal session is rejected before input validation). Mirrors the verified `server.deleteAccount` fix.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
