### PR TITLE
Use resolvePDSHost(for:) in getRepositoryRecord()

### DIFF
--- a/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoGetRecordMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ComAtprotoAPI/ComAtprotoRepoGetRecordMethod.swift
@@ -26,6 +26,7 @@ extension ATProtoKit {
     ///   - collection: The Namespaced Identifier (NSID) of the record.
     ///   - recordKey: The record key of the record.
     ///   - recordCID: The CID hash of the record. Optional.
+    ///   - pdsURL: The URL of the Personal Data Server (PDS). Optional. Defaults to `nil`.
     /// - Returns: The record itself, as well as its URI and CID.
     ///
     /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
@@ -34,9 +35,17 @@ extension ATProtoKit {
         from repository: String,
         collection: String,
         recordKey: String,
-        recordCID: String? = nil
+        recordCID: String? = nil,
+        pdsURL: String? = nil
     ) async throws -> ComAtprotoLexicon.Repository.GetRecordOutput {
-        guard let requestURL = URL(string: "\(self.pdsURL)/xrpc/com.atproto.repo.getRecord") else {
+        let host: String
+        if let pdsURL, !pdsURL.isEmpty {
+            host = pdsURL
+        } else {
+            host = await resolvePDSHost(for: repository)
+        }
+
+        guard let requestURL = URL(string: "\(host)/xrpc/com.atproto.repo.getRecord") else {
             throw ATRequestPrepareError.invalidRequestURL
         }
 


### PR DESCRIPTION
## Description
This PR addresses issue #318 by adding an optional pdsURL parameter to getRepositoryRecord() and updating it to use resolvePDSHost(for:) instead of always sending requests to self.pdsURL. This brings its host resolution behavior in line with describeRepository() and listRecords(), allowing records to be retrieved correctly even when the client is configured to use an AppView.

## Linked Issues
#318

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
N/A

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]

