### PR TITLE
[Bug Fix] Validate reply references via the AppView for cross-PDS replies

### DIFF
--- a/Sources/ATProtoKit/Utilities/ATProtoTools.swift
+++ b/Sources/ATProtoKit/Utilities/ATProtoTools.swift
@@ -31,6 +31,13 @@ public struct ATProtoTools {
 
     /// Determines whether the reply reference is valid.
     ///
+    /// Both the root and parent records are resolved through Bluesky's AppView
+    /// (``APIHostname/bskyAppView``) rather than through a specific Personal Data Server (PDS).
+    /// A reply reference can point to records authored on any PDS, and
+    /// `com.atproto.repo.getRecord` served by a single PDS only returns records for the
+    /// repositories that PDS hosts. Resolving through the AppView allows references to records
+    /// on other PDSes to validate correctly.
+    ///
     /// - Parameters:
     ///   - reference: The reply reference object to check for validity.
     ///   - session: The ``UserSession`` instance in relation to the reply. Optional.
@@ -51,7 +58,7 @@ public struct ATProtoTools {
                 return false
             }
 
-            _ = try await ATProtoKit(pdsURL: session?.pdsURL ?? "https://https://public.api.bsky.app", canUseBlueskyRecords: false).getRepositoryRecord(
+            _ = try await ATProtoKit(pdsURL: APIHostname.bskyAppView, canUseBlueskyRecords: false).getRepositoryRecord(
                 from: repository,
                 collection: collection,
                 recordKey: recordKey
@@ -70,7 +77,7 @@ public struct ATProtoTools {
                 return false
             }
 
-            _ = try await ATProtoKit(pdsURL: session?.pdsURL ?? "https://public.api.bsky.app", canUseBlueskyRecords: false).getRepositoryRecord(
+            _ = try await ATProtoKit(pdsURL: APIHostname.bskyAppView, canUseBlueskyRecords: false).getRepositoryRecord(
                 from: repository,
                 collection: collection,
                 recordKey: recordKey


### PR DESCRIPTION
`isValidReplyReference` resolved the root and parent records through the posting user's PDS (`session.pdsURL`). `com.atproto.repo.getRecord` served by a single PDS only returns records for the repositories that PDS hosts, so any reply whose root or parent is authored on a different PDS failed validation. `createPostRecord` then threw `invalidReplyReference`, blocking otherwise-valid replies to users on third-party PDSes.

Resolve both records through Bluesky's AppView (`APIHostname.bskyAppView`), which resolves records across PDSes. Also removes a duplicated-scheme typo in the root fallback URL (`https://https://`).

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [ ] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [ ] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings or errors in the compiler or runtime.
- [ ] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
