### PR TITLE
Add 40 ReasonTypeDefinition cases from tools.ozone.report.defs

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Moderation/ComAtprotoModerationDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Moderation/ComAtprotoModerationDefs.swift
@@ -60,6 +60,244 @@ extension ComAtprotoLexicon.Moderation {
         /// - Note: According to the AT Protocol specifications: "Appeal: appeal a previously taken
         /// moderation action."
         case appeal = "reasonAppeal"
+
+        /// Indicates an appeal to a previous moderation ruling as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Appeal: appeal a previously taken
+        /// moderation action."
+        case reasonAppeal = "tools.ozone.report.defs#reasonAppeal"
+
+        /// Indicates a reason not otherwise specified (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Other: reports not falling under
+        /// another report category."
+        case reasonOther = "tools.ozone.report.defs#reasonOther"
+
+        /// Indicates animal welfare concerns as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Animal welfare: violence or
+        /// cruelty against animals."
+        case reasonViolenceAnimal = "tools.ozone.report.defs#reasonViolenceAnimal"
+
+        /// Indicates threats or incitement to violence as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Threats or incitement to
+        /// violence."
+        case reasonViolenceThreats = "tools.ozone.report.defs#reasonViolenceThreats"
+
+        /// Indicates graphic violent content as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Graphic violent content:
+        /// disturbing or gory images or videos."
+        case reasonViolenceGraphicContent = "tools.ozone.report.defs#reasonViolenceGraphicContent"
+
+        /// Indicates glorification of violence as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Glorification of violence:
+        /// content that celebrates or promotes violent acts."
+        case reasonViolenceGlorification = "tools.ozone.report.defs#reasonViolenceGlorification"
+
+        /// Indicates extremist content as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Extremist content: material
+        /// promoting or produced by extremist groups."
+        case reasonViolenceExtremistContent = "tools.ozone.report.defs#reasonViolenceExtremistContent"
+
+        /// Indicates human trafficking as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Human trafficking: content
+        /// facilitating or promoting the trafficking of persons."
+        case reasonViolenceTrafficking = "tools.ozone.report.defs#reasonViolenceTrafficking"
+
+        /// Indicates violent content not otherwise specified as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Other violent content not covered
+        /// by more specific categories."
+        case reasonViolenceOther = "tools.ozone.report.defs#reasonViolenceOther"
+
+        /// Indicates adult sexual abuse content as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Adult sexual abuse content."
+        case reasonSexualAbuseContent = "tools.ozone.report.defs#reasonSexualAbuseContent"
+
+        /// Indicates non-consensual intimate imagery (NCII) as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Non-consensual intimate imagery
+        /// (NCII): sharing intimate images without the subject's consent."
+        case reasonSexualNCII = "tools.ozone.report.defs#reasonSexualNCII"
+
+        /// Indicates a sexual deepfake as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Deepfake adult content:
+        /// AI-generated or manipulated sexual imagery."
+        case reasonSexualDeepfake = "tools.ozone.report.defs#reasonSexualDeepfake"
+
+        /// Indicates sexual content involving animals as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Animal sexual abuse: sexual
+        /// content involving animals."
+        case reasonSexualAnimal = "tools.ozone.report.defs#reasonSexualAnimal"
+
+        /// Indicates unlabeled adult content as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Unlabeled adult content: explicit
+        /// material posted without appropriate content labels."
+        case reasonSexualUnlabeled = "tools.ozone.report.defs#reasonSexualUnlabeled"
+
+        /// Indicates sexual content not otherwise specified as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Other sexual content not covered
+        /// by more specific categories."
+        case reasonSexualOther = "tools.ozone.report.defs#reasonSexualOther"
+
+        /// Indicates child sexual abuse material (CSAM) as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Child Sexual Abuse Material
+        /// (CSAM)."
+        case reasonChildSafetyCSAM = "tools.ozone.report.defs#reasonChildSafetyCSAM"
+
+        /// Indicates grooming or predatory behavior targeting minors as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Grooming or predatory behavior
+        /// targeting minors."
+        case reasonChildSafetyGroom = "tools.ozone.report.defs#reasonChildSafetyGroom"
+
+        /// Indicates a privacy violation involving a minor as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Privacy violation of a minor:
+        /// exposing a child's personal information without consent."
+        case reasonChildSafetyPrivacy = "tools.ozone.report.defs#reasonChildSafetyPrivacy"
+
+        /// Indicates harassment or bullying of a minor as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Minor harassment or bullying."
+        case reasonChildSafetyHarassment = "tools.ozone.report.defs#reasonChildSafetyHarassment"
+
+        /// Indicates a child safety concern not otherwise specified as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Other child safety concern not
+        /// covered by more specific categories."
+        case reasonChildSafetyOther = "tools.ozone.report.defs#reasonChildSafetyOther"
+
+        /// Indicates trolling as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Trolling: disruptive or
+        /// provocative behavior intended to upset others."
+        case reasonHarassmentTroll = "tools.ozone.report.defs#reasonHarassmentTroll"
+
+        /// Indicates targeted harassment as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Targeted harassment: sustained
+        /// abusive behavior directed at a specific individual."
+        case reasonHarassmentTargeted = "tools.ozone.report.defs#reasonHarassmentTargeted"
+
+        /// Indicates hate speech as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Hate speech: content attacking
+        /// individuals or groups based on protected characteristics."
+        case reasonHarassmentHateSpeech = "tools.ozone.report.defs#reasonHarassmentHateSpeech"
+
+        /// Indicates doxxing as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Doxxing: publishing private or
+        /// personal information without the subject's consent."
+        case reasonHarassmentDoxxing = "tools.ozone.report.defs#reasonHarassmentDoxxing"
+
+        /// Indicates harassing or hateful content not otherwise specified as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Other harassing or hateful
+        /// content not covered by more specific categories."
+        case reasonHarassmentOther = "tools.ozone.report.defs#reasonHarassmentOther"
+
+        /// Indicates a fake account or bot as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Fake account or bot: inauthentic
+        /// account that is automated or misrepresents its identity."
+        case reasonMisleadingBot = "tools.ozone.report.defs#reasonMisleadingBot"
+
+        /// Indicates impersonation as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Impersonation: falsely claiming
+        /// to be another person or entity."
+        case reasonMisleadingImpersonation = "tools.ozone.report.defs#reasonMisleadingImpersonation"
+
+        /// Indicates misleading spam as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Spam: frequent unwanted
+        /// promotion, replies, or mentions."
+        case reasonMisleadingSpam = "tools.ozone.report.defs#reasonMisleadingSpam"
+
+        /// Indicates a scam as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Scam: deceptive content intended
+        /// to defraud users."
+        case reasonMisleadingScam = "tools.ozone.report.defs#reasonMisleadingScam"
+
+        /// Indicates false information about elections as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "False information about elections:
+        /// misleading content related to electoral processes or voting."
+        case reasonMisleadingElections = "tools.ozone.report.defs#reasonMisleadingElections"
+
+        /// Indicates misleading content not otherwise specified as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Other misleading content not
+        /// covered by more specific categories."
+        case reasonMisleadingOther = "tools.ozone.report.defs#reasonMisleadingOther"
+
+        /// Indicates a site security violation as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Site security violation: hacking,
+        /// phishing, or other attacks on the network or its users."
+        case reasonRuleSiteSecurity = "tools.ozone.report.defs#reasonRuleSiteSecurity"
+
+        /// Indicates the promotion or sale of prohibited items or services as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Promoting or selling prohibited
+        /// items or services."
+        case reasonRuleProhibitedSales = "tools.ozone.report.defs#reasonRuleProhibitedSales"
+
+        /// Indicates ban evasion as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Ban evasion: a previously banned
+        /// user returning with a new account."
+        case reasonRuleBanEvasion = "tools.ozone.report.defs#reasonRuleBanEvasion"
+
+        /// Indicates a rule violation not otherwise specified as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Other network rule violation not
+        /// covered by more specific categories."
+        case reasonRuleOther = "tools.ozone.report.defs#reasonRuleOther"
+
+        /// Indicates content promoting or depicting self-harm as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Content promoting or depicting
+        /// self-harm."
+        case reasonSelfHarmContent = "tools.ozone.report.defs#reasonSelfHarmContent"
+
+        /// Indicates eating disorder-related content as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Eating disorders: material
+        /// promoting or glorifying disordered eating behaviors."
+        case reasonSelfHarmED = "tools.ozone.report.defs#reasonSelfHarmED"
+
+        /// Indicates dangerous challenges or activities as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Dangerous challenges or
+        /// activities: content encouraging high-risk physical stunts."
+        case reasonSelfHarmStunts = "tools.ozone.report.defs#reasonSelfHarmStunts"
+
+        /// Indicates dangerous substance use or drug abuse as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Dangerous substances or drug
+        /// abuse: content promoting harmful substance use."
+        case reasonSelfHarmSubstances = "tools.ozone.report.defs#reasonSelfHarmSubstances"
+
+        /// Indicates dangerous content not otherwise specified as the reason (Ozone reporting system).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Other dangerous content not
+        /// covered by more specific categories."
+        case reasonSelfHarmOther = "tools.ozone.report.defs#reasonSelfHarmOther"
     }
 
     /// A definition model for a tag describing a possible subject for reporting.


### PR DESCRIPTION
## Description
`ComAtprotoLexicon.Moderation.ReasonTypeDefinition` currently covers only the original 7 values defined in `com.atproto.moderation.defs`. However, the upstream lexicon now defines 47 known values in total — the additional 40 are namespaced under `tools.ozone.report.defs` and span Violence, Sexual, Child Safety, Harassment, Misleading, Rule, and Self-Harm categories.

This PR adds all 40 missing cases so that callers of `createReport` can pass any known reason type through the typed Swift API without resorting to raw strings or bypassing the enum entirely.

No existing cases are modified or removed, so this is a purely additive change.

## Linked Issues
#326

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
The 40 new cases are added in lexicon order, grouped by category (Appeal / Other, Violence, Sexual, Child Safety, Harassment, Misleading, Rule, Self-Harm). Each case's raw value matches the corresponding `knownValues` entry in the upstream lexicon exactly.

Several of the new fragment names (e.g. `appeal`, `other`, `spam`) would have collided with existing cases already defined from `com.atproto.moderation.defs`. To avoid ambiguity within the same enum, all 40 new cases are prefixed with `reason` (e.g. `reasonAppeal`, `reasonOther`, `reasonMisleadingSpam`).

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
