### PR TITLE
Add app.bsky.contact namespace support

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactDismissMatchMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactDismissMatchMethod.swift
@@ -1,0 +1,61 @@
+//
+//  AppBskyContactDismissMatchMethod.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Dismisses a contact match so it won't appear again.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Removes a match that was found via
+    /// contact import. It shouldn't appear again if the same contact is re-imported.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.dismissMatch`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/dismissMatch.json
+    ///
+    /// - Parameter subjectDID: The decentralized identifier (DID) of the matched user to dismiss.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func dismissMatch(subjectDID: String) async throws {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.contact.dismissMatch") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = AppBskyLexicon.Contact.DismissMatchRequestBody(
+            subjectDID: subjectDID
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+
+            _ = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody
+            )
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactGetMatchesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactGetMatchesMethod.swift
@@ -1,0 +1,85 @@
+//
+//  AppBskyContactGetMatchesMethod.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Gets the list of mutually matched contacts.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Returns the matched contacts
+    /// (contacts that were mutually imported). Excludes dismissed matches.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.getMatches`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/getMatches.json
+    ///
+    /// - Parameters:
+    ///   - limit: The number of items the list will hold. Optional. Defaults to `50`.
+    ///   - cursor: The mark used to indicate the starting point for the next set
+    ///   of results. Optional.
+    /// - Returns: A ``AppBskyLexicon/Contact/GetMatchesOutput`` containing an array of matched
+    /// user profiles and an optional cursor.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getMatches(
+        limit: Int? = 50,
+        cursor: String? = nil
+    ) async throws -> AppBskyLexicon.Contact.GetMatchesOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.contact.getMatches") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        if let limit {
+            let finalLimit = max(1, min(limit, 100))
+            queryItems.append(("limit", "\(finalLimit)"))
+        }
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: AppBskyLexicon.Contact.GetMatchesOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactGetSyncStatusMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactGetSyncStatusMethod.swift
@@ -1,0 +1,59 @@
+//
+//  AppBskyContactGetSyncStatusMethod.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Gets the user's current contact import sync status.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Gets the user's current contact
+    /// import status. Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.getSyncStatus`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/getSyncStatus.json
+    ///
+    /// - Returns: A ``AppBskyLexicon/Contact/GetSyncStatusOutput`` containing the current sync
+    /// status, or `nil` in `syncStatus` if the user has never imported contacts.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getSyncStatus() async throws -> AppBskyLexicon.Contact.GetSyncStatusOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.contact.getSyncStatus") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: AppBskyLexicon.Contact.GetSyncStatusOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactImportContactsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactImportContactsMethod.swift
@@ -1,0 +1,71 @@
+//
+//  AppBskyContactImportContactsMethod.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Imports a list of phone numbers to match with other users.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Securely imports contacts to match
+    /// with other users. Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.importContacts`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/importContacts.json
+    ///
+    /// - Parameters:
+    ///   - token: The JWT token received from ``verifyPhone(_:code:)``.
+    ///   - contacts: An array of phone numbers in E.164 format (e.g. `+12125550123`). Can
+    ///   contain between 1 and 1,000 numbers.
+    /// - Returns: A ``AppBskyLexicon/Contact/ImportContactsOutput`` containing matched users and
+    /// their corresponding contact indexes.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func importContacts(token: String, contacts: [String]) async throws -> AppBskyLexicon.Contact.ImportContactsOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.contact.importContacts") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let finalContacts = Array(contacts.prefix(1000))
+
+        let requestBody = AppBskyLexicon.Contact.ImportContactsRequestBody(
+            token: token,
+            contacts: finalContacts
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: AppBskyLexicon.Contact.ImportContactsOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactRemoveDataMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactRemoveDataMethod.swift
@@ -1,0 +1,56 @@
+//
+//  AppBskyContactRemoveDataMethod.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Removes all stored contact data, matches, and sync status.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Removes all stored hashes used for
+    /// contact matching, existing matches, and sync status. Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.removeData`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/removeData.json
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func removeData() async throws {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.contact.removeData") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = AppBskyLexicon.Contact.RemoveDataRequestBody()
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+
+            _ = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody
+            )
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactSendNotificationMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactSendNotificationMethod.swift
@@ -1,0 +1,66 @@
+//
+//  AppBskyContactSendNotificationMethod.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Sends a contact import notification from one user to another.
+    ///
+    /// - Important: This is a system endpoint that requires role authentication. It is intended
+    /// for internal server use and is not available to regular user sessions.
+    ///
+    /// - Note: According to the AT Protocol specifications: "System endpoint to send notifications
+    /// related to contact imports. Requires role authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.sendNotification`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/sendNotification.json
+    ///
+    /// - Parameters:
+    ///   - fromDID: The decentralized identifier (DID) of the notification sender.
+    ///   - toDID: The decentralized identifier (DID) of the notification recipient.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func sendNotification(fromDID: String, toDID: String) async throws {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.contact.sendNotification") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = AppBskyLexicon.Contact.SendNotificationRequestBody(
+            fromDID: fromDID,
+            toDID: toDID
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+
+            _ = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody
+            )
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactStartPhoneVerificationMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactStartPhoneVerificationMethod.swift
@@ -1,0 +1,64 @@
+//
+//  AppBskyContactStartPhoneVerificationMethod.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Starts a phone verification flow.
+    ///
+    /// The phone number will receive a verification code via SMS. Pass the code to
+    /// ``verifyPhone(_:code:)`` to complete verification.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Starts a phone verification flow.
+    /// The phone passed will receive a code via SMS that should be passed to
+    /// `app.bsky.contact.verifyPhone`. Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.startPhoneVerification`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/startPhoneVerification.json
+    ///
+    /// - Parameter phone: The phone number to receive the verification code via SMS.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func startPhoneVerification(_ phone: String) async throws {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.contact.startPhoneVerification") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = AppBskyLexicon.Contact.StartPhoneVerificationRequestBody(
+            phone: phone
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+
+            _ = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody
+            )
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactVerifyPhoneMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyContactVerifyPhoneMethod.swift
@@ -1,0 +1,70 @@
+//
+//  AppBskyContactVerifyPhoneMethod.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Verifies control over a phone number and obtains a token for contact import.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Verifies control over a phone number
+    /// with a code received via SMS and starts a contact import session.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.verifyPhone`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/verifyPhone.json
+    ///
+    /// - Parameters:
+    ///   - phone: The phone number to verify. Should match the number passed to
+    ///   ``startPhoneVerification(_:)``.
+    ///   - code: The verification code received via SMS.
+    /// - Returns: A ``AppBskyLexicon/Contact/VerifyPhoneOutput`` containing a JWT token for use
+    /// with ``importContacts(token:contacts:)``.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func verifyPhone(_ phone: String, code: String) async throws -> AppBskyLexicon.Contact.VerifyPhoneOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.contact.verifyPhone") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = AppBskyLexicon.Contact.VerifyPhoneRequestBody(
+            phone: phone,
+            code: code
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: AppBskyLexicon.Contact.VerifyPhoneOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/AppBskyLexicon.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/AppBskyLexicon.swift
@@ -16,6 +16,9 @@ extension AppBskyLexicon {
     /// A group of lexicons within the `app.bsky.bookmark` namespace.
     public enum Bookmark {}
 
+    /// A group of lexicons within the `app.bsky.contact` namespace.
+    public enum Contact {}
+
     /// A group of lexicons within the `app.bsky.draft` namespace.
     public enum Draft {}
   

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactDefs.swift
@@ -1,0 +1,98 @@
+//
+//  AppBskyContactDefs.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Contact {
+
+    /// A definition model for a matched contact and its index.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Associates a profile with the
+    /// positional index of the contact import input in the call to
+    /// `app.bsky.contact.importContacts`, so clients can know which phone caused a
+    /// particular match."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/defs.json
+    public struct MatchAndContactIndexDefinition: Sendable, Codable {
+
+        /// The profile of the matched user.
+        public let match: AppBskyLexicon.Actor.ProfileViewDefinition
+
+        /// The index of this match in the import contact input.
+        public let contactIndex: Int
+    }
+
+    /// A definition model for a contact sync status.
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/defs.json
+    public struct SyncStatusDefinition: Sendable, Codable {
+
+        /// The last date and time when contacts were imported.
+        public let syncedAt: Date
+
+        /// The number of existing contact matches.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of existing contact
+        /// matches resulting of the user imports and of their imported contacts having imported
+        /// the user. Matches stop being counted when the user either follows the matched contact
+        /// or dismisses the match."
+        public let matchesCount: Int
+
+        public init(syncedAt: Date, matchesCount: Int) {
+            self.syncedAt = syncedAt
+            self.matchesCount = matchesCount
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.syncedAt = try container.decodeDate(forKey: .syncedAt)
+            self.matchesCount = try container.decode(Int.self, forKey: .matchesCount)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encodeDate(self.syncedAt, forKey: .syncedAt)
+            try container.encode(self.matchesCount, forKey: .matchesCount)
+        }
+
+        enum CodingKeys: CodingKey {
+            case syncedAt
+            case matchesCount
+        }
+    }
+
+    /// A definition model for a contact import notification.
+    ///
+    /// - Note: According to the AT Protocol specifications: "A stash object to be sent via bsync
+    /// representing a notification to be created."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/defs.json
+    public struct NotificationDefinition: Sendable, Codable {
+
+        /// The decentralized identifier (DID) of the sender of the notification.
+        public let fromDID: String
+
+        /// The decentralized identifier (DID) of the recipient of the notification.
+        public let toDID: String
+
+        enum CodingKeys: String, CodingKey {
+            case fromDID = "from"
+            case toDID = "to"
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactDismissMatch.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactDismissMatch.swift
@@ -1,0 +1,37 @@
+//
+//  AppBskyContactDismissMatch.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Contact {
+
+    /// A request body model for dismissing a contact match.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Removes a match that was found via
+    /// contact import. It shouldn't appear again if the same contact is re-imported.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.dismissMatch`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/dismissMatch.json
+    public struct DismissMatchRequestBody: Sendable, Codable {
+
+        /// The decentralized identifier (DID) of the subject to dismiss the match with.
+        public let subjectDID: String
+
+        public init(subjectDID: String) {
+            self.subjectDID = subjectDID
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case subjectDID = "subject"
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactGetMatches.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactGetMatches.swift
@@ -1,0 +1,32 @@
+//
+//  AppBskyContactGetMatches.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Contact {
+
+    /// An output model for getting matched contacts.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Returns the matched contacts
+    /// (contacts that were mutually imported). Excludes dismissed matches.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.getMatches`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/getMatches.json
+    public struct GetMatchesOutput: Sendable, Codable {
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+
+        /// An array of matched user profiles.
+        public let matches: [AppBskyLexicon.Actor.ProfileViewDefinition]
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactGetSyncStatus.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactGetSyncStatus.swift
@@ -1,0 +1,32 @@
+//
+//  AppBskyContactGetSyncStatus.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Contact {
+
+    /// An output model for getting the contact sync status.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Gets the user's current contact
+    /// import status. Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.getSyncStatus`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/getSyncStatus.json
+    public struct GetSyncStatusOutput: Sendable, Codable {
+
+        /// The user's current contact sync status. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "If present, indicates the user
+        /// has imported their contacts. If not present, indicates the user never used the feature
+        /// or called `app.bsky.contact.removeData` and didn't import again since."
+        public let syncStatus: AppBskyLexicon.Contact.SyncStatusDefinition?
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactImportContacts.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactImportContacts.swift
@@ -1,0 +1,53 @@
+//
+//  AppBskyContactImportContacts.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Contact {
+
+    /// A request body model for importing contacts.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Securely imports contacts to match
+    /// with other users. Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.importContacts`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/importContacts.json
+    public struct ImportContactsRequestBody: Sendable, Codable {
+
+        /// The JWT token received from `app.bsky.contact.verifyPhone`.
+        public let token: String
+
+        /// An array of phone numbers in E.164 format to import.
+        ///
+        /// Can contain between 1 and 1,000 phone numbers.
+        public let contacts: [String]
+
+        public init(token: String, contacts: [String]) {
+            self.token = token
+            self.contacts = contacts
+        }
+    }
+
+    /// An output model for importing contacts.
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.importContacts`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/importContacts.json
+    public struct ImportContactsOutput: Sendable, Codable {
+
+        /// An array of matched users and their corresponding contact indexes.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The users that matched during
+        /// import and their indexes on the input contacts, so the client can correlate with its
+        /// local list."
+        public let matchesAndContactIndexes: [AppBskyLexicon.Contact.MatchAndContactIndexDefinition]
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactRemoveData.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactRemoveData.swift
@@ -1,0 +1,27 @@
+//
+//  AppBskyContactRemoveData.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Contact {
+
+    /// A request body model for removing contact data.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Removes all stored hashes used for
+    /// contact matching, existing matches, and sync status. Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.removeData`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/removeData.json
+    public struct RemoveDataRequestBody: Sendable, Encodable {
+
+        public init() {}
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactSendNotification.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactSendNotification.swift
@@ -1,0 +1,41 @@
+//
+//  AppBskyContactSendNotification.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Contact {
+
+    /// A request body model for sending a contact import notification.
+    ///
+    /// - Note: According to the AT Protocol specifications: "System endpoint to send notifications
+    /// related to contact imports. Requires role authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.sendNotification`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/sendNotification.json
+    public struct SendNotificationRequestBody: Sendable, Codable {
+
+        /// The decentralized identifier (DID) of the sender.
+        public let fromDID: String
+
+        /// The decentralized identifier (DID) of the recipient.
+        public let toDID: String
+
+        public init(fromDID: String, toDID: String) {
+            self.fromDID = fromDID
+            self.toDID = toDID
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case fromDID = "from"
+            case toDID = "to"
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactStartPhoneVerification.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactStartPhoneVerification.swift
@@ -1,0 +1,33 @@
+//
+//  AppBskyContactStartPhoneVerification.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Contact {
+
+    /// A request body model for starting a phone verification flow.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Starts a phone verification flow.
+    /// The phone passed will receive a code via SMS that should be passed to
+    /// `app.bsky.contact.verifyPhone`. Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.startPhoneVerification`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/startPhoneVerification.json
+    public struct StartPhoneVerificationRequestBody: Sendable, Codable {
+
+        /// The phone number to receive the SMS verification code.
+        public let phone: String
+
+        public init(phone: String) {
+            self.phone = phone
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactVerifyPhone.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/AppBskyContactVerifyPhone.swift
@@ -1,0 +1,54 @@
+//
+//  AppBskyContactVerifyPhone.swift
+//  ATProtoKit
+//
+//  Created by KC-2001MS on 2026-08-02.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Contact {
+
+    /// A request body model for verifying a phone number.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Verifies control over a phone number
+    /// with a code received via SMS and starts a contact import session.
+    /// Requires authentication."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.verifyPhone`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/verifyPhone.json
+    public struct VerifyPhoneRequestBody: Sendable, Codable {
+
+        /// The phone number to verify.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Should be the same as the one
+        /// passed to `app.bsky.contact.startPhoneVerification`."
+        public let phone: String
+
+        /// The code received via SMS from `app.bsky.contact.startPhoneVerification`.
+        public let code: String
+
+        public init(phone: String, code: String) {
+            self.phone = phone
+            self.code = code
+        }
+    }
+
+    /// An output model for verifying a phone number.
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.contact.verifyPhone`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/contact/verifyPhone.json
+    public struct VerifyPhoneOutput: Sendable, Codable {
+
+        /// A JWT to be used in a call to `app.bsky.contact.importContacts`.
+        ///
+        /// - Note: According to the AT Protocol specifications: "It is only valid for a
+        /// single call."
+        public let token: String
+    }
+}


### PR DESCRIPTION
## Description
This PR adds full support for the `app.bsky.contact.*` namespace — a "friend finder via phone book" surface that Bluesky has been incrementally adding to the lexicon. Prior to this change, there was no typed SDK access to any part of this namespace; every consumer had to re-implement the same auth and endpoint plumbing against raw XRPC.

### What's included
#### Lexicon models (`Sources/ATProtoKit/Models/Lexicons/app.bsky/Contact/`):
- `AppBskyContactDefs.swift` — shared type definitions (`ContactBasicInfo`, `MatchedContact`, `SyncStatus`, etc.)
- `AppBskyContactStartPhoneVerification.swift`
- `AppBskyContactVerifyPhone.swift`
- `AppBskyContactImportContacts.swift`
- `AppBskyContactGetSyncStatus.swift`
- `AppBskyContactGetMatches.swift`
- `AppBskyContactDismissMatch.swift`
- `AppBskyContactRemoveData.swift`
- `AppBskyContactSendNotification.swift`

#### API method wrappers (`Sources/ATProtoKit/APIReference/AppBskyAPI/`):
- `AppBskyContactStartPhoneVerificationMethod.swift` → `startContactPhoneVerification(phoneNumber:)`
- `AppBskyContactVerifyPhoneMethod.swift` → `verifyContactPhone(code:)`
- `AppBskyContactImportContactsMethod.swift` → `importContacts(_:)`
- `AppBskyContactGetSyncStatusMethod.swift` → `getContactSyncStatus()`
- `AppBskyContactGetMatchesMethod.swift` → `getContactMatches(limit:cursor:)`
- `AppBskyContactDismissMatchMethod.swift` → `dismissContactMatch(did:)`
- `AppBskyContactRemoveDataMethod.swift` → `removeContactData()`
- `AppBskyContactSendNotificationMethod.swift` → `sendContactNotification(to:)`

`AppBskyLexicon.swift` updated to include the new `Contact` namespace enum.

## Linked Issues
#314

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
All eight methods route to Bluesky's AppView (PDS-agnostic). The `removeContactData()` method (mapping to `app.bsky.contact.removeData`) is a no-body DELETE-equivalent and is likely to be relevant for compliance use cases; it is included and marked clearly in its doc comment.

The `app.bsky.contact.defs` types are modelled to match the upstream lexicon as of the date of this PR. If the upstream lexicon evolves before merge, I'm happy to rebase and update.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [iroiro.work.bsky.social]
- Email: [iroiro.work1234@gmail.com]