### PR TITLE
Add chat.bsky.notification namespace support

### DIFF
--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyNotificationGetPreferencesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyNotificationGetPreferencesMethod.swift
@@ -1,0 +1,59 @@
+//
+//  ChatBskyNotificationGetPreferencesMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-12.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoBlueskyChat {
+
+    /// Gets chat notification preferences for a user account.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get the requesting account's chat
+    /// notification preferences. Defaults are returned for accounts that have not set any
+    /// preferences. Requires auth."
+    ///
+    /// - SeeAlso: This is based on the [`chat.bsky.notification.getPreferences`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/chat/bsky/notification/getPreferences.json
+    ///
+    /// - Returns: The chat notification preferences for the user account.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getChatNotificationPreferences() async throws -> ChatBskyLexicon.Notification.GetPreferencesOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.notification.getPreferences") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true,
+                isRelatedToBskyChat: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: ChatBskyLexicon.Notification.GetPreferencesOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyNotificationPutPreferencesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/ChatBskyAPI/ChatBskyNotificationPutPreferencesMethod.swift
@@ -1,0 +1,71 @@
+//
+//  ChatBskyNotificationPutPreferencesMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-12.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoBlueskyChat {
+
+    /// Sets chat notification preferences for a user account.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Set the requesting account's chat
+    /// notification preferences. Only the provided preferences are updated; omitted preferences
+    /// are left unchanged."
+    ///
+    /// - SeeAlso: This is based on the [`chat.bsky.notification.putPreferences`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/chat/bsky/notification/putPreferences.json
+    ///
+    /// - Parameters:
+    ///   - chat: Notification preferences for accepted conversations. Optional.
+    ///   - chatRequest: Notification preferences for conversation requests. Optional.
+    /// - Returns: The updated chat notification preferences.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func putChatNotificationPreferences(
+        chat: ChatBskyLexicon.Notification.ChatPreferenceDefinition? = nil,
+        chatRequest: ChatBskyLexicon.Notification.ChatPreferenceDefinition? = nil
+    ) async throws -> ChatBskyLexicon.Notification.PutPreferencesOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/chat.bsky.notification.putPreferences") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ChatBskyLexicon.Notification.PutPreferencesRequestBody(
+            chat: chat,
+            chatRequest: chatRequest
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true,
+                isRelatedToBskyChat: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: ChatBskyLexicon.Notification.PutPreferencesOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/chat.bsky/ChatBskyLexicon.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/chat.bsky/ChatBskyLexicon.swift
@@ -15,4 +15,7 @@ extension ChatBskyLexicon {
 
     /// A group of lexicons within the `chat.bsky.moderation` namespace.
     public enum Moderation {}
+
+    /// A group of lexicons within the `chat.bsky.notification` namespace.
+    public enum Notification {}
 }

--- a/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Notification/ChatBskyNotificationDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Notification/ChatBskyNotificationDefs.swift
@@ -1,0 +1,95 @@
+//
+//  ChatBskyNotificationDefs.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-12.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ChatBskyLexicon.Notification {
+
+    /// A definition model for a chat notification preference entry.
+    ///
+    /// - SeeAlso: This is based on the [`chat.bsky.notification.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/chat/bsky/notification/defs.json
+    public struct ChatPreferenceDefinition: Sendable, Codable {
+
+        /// A filter of which conversations trigger push notifications.
+        public let include: Include
+
+        /// Determines whether push notifications for chat messages are enabled.
+        public let willPush: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case include
+            case willPush = "push"
+        }
+
+        // Enums
+        /// A filter of which conversations trigger push notifications.
+        public enum Include: Sendable, Codable, ExpressibleByStringLiteral {
+
+            /// Include notifications from all conversations.
+            case all
+
+            /// Include notifications only from accounts the user follows.
+            case follows
+
+            /// An unknown value that the object may contain.
+            case unknown(String)
+
+            public var rawValue: String {
+                switch self {
+                    case .all:
+                        return "all"
+                    case .follows:
+                        return "follows"
+                    case .unknown(let value):
+                        return value
+                }
+            }
+
+            public init(stringLiteral value: String) {
+                self = .unknown(value)
+            }
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let value = try container.decode(String.self)
+
+                switch value {
+                    case "all":
+                        self = .all
+                    case "follows":
+                        self = .follows
+                    default:
+                        self = .unknown(value)
+                }
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                try container.encode(self.rawValue)
+            }
+        }
+    }
+
+    /// A definition model for the full set of chat notification preferences.
+    ///
+    /// - SeeAlso: This is based on the [`chat.bsky.notification.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/chat/bsky/notification/defs.json
+    public struct PreferencesDefinition: Sendable, Codable {
+
+        /// Notification preferences for accepted conversations.
+        public let chat: ChatPreferenceDefinition
+
+        /// Notification preferences for conversation requests.
+        public let chatRequest: ChatPreferenceDefinition
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Notification/ChatBskyNotificationGetPreferences.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Notification/ChatBskyNotificationGetPreferences.swift
@@ -1,0 +1,29 @@
+//
+//  ChatBskyNotificationGetPreferences.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-12.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ChatBskyLexicon.Notification {
+
+    /// An output model for getting chat notification preferences for a user account.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get the requesting account's chat
+    /// notification preferences. Defaults are returned for accounts that have not set any
+    /// preferences. Requires auth."
+    ///
+    /// - SeeAlso: This is based on the [`chat.bsky.notification.getPreferences`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/chat/bsky/notification/getPreferences.json
+    public struct GetPreferencesOutput: Sendable, Codable {
+
+        /// The chat notification preferences for the user account.
+        public let preferences: ChatBskyLexicon.Notification.PreferencesDefinition
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Notification/ChatBskyNotificationPutPreferences.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/chat.bsky/Notification/ChatBskyNotificationPutPreferences.swift
@@ -1,0 +1,47 @@
+//
+//  ChatBskyNotificationPutPreferences.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-12.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ChatBskyLexicon.Notification {
+
+    /// A request body model for setting chat notification preferences for a user account.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Set the requesting account's chat
+    /// notification preferences. Only the provided preferences are updated; omitted preferences
+    /// are left unchanged."
+    ///
+    /// - SeeAlso: This is based on the [`chat.bsky.notification.putPreferences`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/chat/bsky/notification/putPreferences.json
+    public struct PutPreferencesRequestBody: Sendable, Codable {
+
+        /// Notification preferences for accepted conversations. Optional.
+        public let chat: ChatBskyLexicon.Notification.ChatPreferenceDefinition?
+
+        /// Notification preferences for conversation requests. Optional.
+        public let chatRequest: ChatBskyLexicon.Notification.ChatPreferenceDefinition?
+    }
+
+    /// An output model for setting chat notification preferences for a user account.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Set the requesting account's chat
+    /// notification preferences. Only the provided preferences are updated; omitted preferences
+    /// are left unchanged."
+    ///
+    /// - SeeAlso: This is based on the [`chat.bsky.notification.putPreferences`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/chat/bsky/notification/putPreferences.json
+    public struct PutPreferencesOutput: Sendable, Codable {
+
+        /// The updated chat notification preferences.
+        public let preferences: ChatBskyLexicon.Notification.PreferencesDefinition
+    }
+}


### PR DESCRIPTION
## Description
Adds typed support for the `chat.bsky.notification` namespace, which provides DM notification preference management on the `api.bsky.chat` host.

### Added files

**Lexicon models** (`Sources/ATProtoKit/Models/Lexicons/chat.bsky/Notification/`):
- `ChatBskyNotificationDefs.swift` — `ChatPreferenceDefinition` (include filter + push toggle) and `PreferencesDefinition` (accepted chats + chat requests)
- `ChatBskyNotificationGetPreferences.swift` — `GetPreferencesOutput`
- `ChatBskyNotificationPutPreferences.swift` — `PutPreferencesRequestBody` and `PutPreferencesOutput`

**API methods** (`Sources/ATProtoKit/APIReference/ChatBskyAPI/`):
- `ChatBskyNotificationGetPreferencesMethod.swift` — `getChatNotificationPreferences()` on `ATProtoBlueskyChat`
- `ChatBskyNotificationPutPreferencesMethod.swift` — `putChatNotificationPreferences(chat:chatRequest:)` on `ATProtoBlueskyChat`

Both methods use `isRelatedToBskyChat: true` to route requests through `api.bsky.chat` as required by the lexicon.

## Linked Issues
#322

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
This implementation serves as an interim typed layer for `chat.bsky.notification` until ATLexiconC covers this namespace. If this PR is useful before ATLexiconC lands, feel free to merge it; if ATLexiconC will supersede it, feel free to close without merging — no pressure either way.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]