### PR TITLE
Add getEmbedExternalView, searchPostsV2, and getStarterPacksWithMembership

### DIFF
--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyEmbedGetEmbedExternalViewMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyEmbedGetEmbedExternalViewMethod.swift
@@ -1,0 +1,83 @@
+//
+//  AppBskyEmbedGetEmbedExternalViewMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-10.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Resolves one or more AT-URIs into the data needed to render an enhanced external embed.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Resolve one or more AT-URIs into
+    /// the data needed to render an enhanced external embed. Returns `associatedRefs`
+    /// (strongRefs to embed into a post's external.associatedRefs), the raw `associatedRecords`,
+    /// and a hydrated `view`. The response is empty (`{}`) when no records were resolvable, or
+    /// when validation determined the resolved records don't actually back the requested URL;
+    /// clients should fall back to their own link-card rendering in that case and skip writing
+    /// strongRefs to the post."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.embed.getEmbedExternalView`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/getEmbedExternalView.json
+    ///
+    /// - Parameters:
+    ///   - url: The canonical web URL the embed represents. Used as the returned view's `uri`.
+    ///   - uris: AT-URIs of Atmosphere records that can be resolved and used to construct
+    ///   the embed view. Current maximum is 4 items.
+    /// - Returns: A hydrated embed view, associated strong references, and raw record data.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getEmbedExternalView(
+        url: String,
+        uris: [String]
+    ) async throws -> AppBskyLexicon.Embed.GetEmbedExternalViewOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.embed.getEmbedExternalView") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        queryItems.append(("url", url))
+
+        let cappedURIs = uris.prefix(4)
+        queryItems += cappedURIs.map { ("uris", $0) }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: AppBskyLexicon.Embed.GetEmbedExternalViewOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedSearchPostsV2Method.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedSearchPostsV2Method.swift
@@ -1,0 +1,252 @@
+//
+//  AppBskyFeedSearchPostsV2Method.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-10.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Retrieves the results of a v2 search query.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Find posts matching a search query
+    /// or filters, returning search hits for matching post records."
+    ///
+    /// - Note: A `query` string or at least one filter parameter is required.
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.feed.searchPostsV2`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/feed/searchPostsV2.json
+    ///
+    /// - Parameters:
+    ///   - query: Search query string. Optional, but a query or at least one filter is required.
+    ///   - sort: Ranking order for results. Optional.
+    ///   - authors: Include posts by any of these authors (AT Identifiers). Optional.
+    ///   - mentions: Include posts that mention any of these accounts (AT Identifiers). Optional.
+    ///   - domains: Include posts that link to any of these domains. Optional.
+    ///   - urls: Include posts that link to any of these URLs. Optional.
+    ///   - embeddedAtURIs: Include posts that embed any of these AT URIs. Optional.
+    ///   - hashtags: Include posts tagged with any of these hashtags (without the `#` prefix). Optional.
+    ///   - excludeAuthors: Exclude posts by any of these authors (AT Identifiers). Optional.
+    ///   - excludeMentions: Exclude posts mentioning any of these accounts (AT Identifiers). Optional.
+    ///   - excludeDomains: Exclude posts linking to any of these domains. Optional.
+    ///   - excludeURLs: Exclude posts linking to any of these URLs. Optional.
+    ///   - excludeEmbeddedAtURIs: Exclude posts embedding any of these AT URIs. Optional.
+    ///   - excludeHashtags: Exclude posts tagged with any of these hashtags (without the `#` prefix). Optional.
+    ///   - since: Include posts indexed at or after this date and time. Optional.
+    ///   - until: Include posts indexed before this date and time. Defaults to the current time. Optional.
+    ///   - allTime: Search the full index instead of the recent-post window. Optional.
+    ///   - languages: Include posts whose language matches any of these language codes. Optional.
+    ///   - excludeLanguages: Exclude posts whose language matches any of these language codes. Optional.
+    ///   - hasMedia: Include only posts with media. Optional.
+    ///   - hasVideo: Include only posts with video. Optional.
+    ///   - replyParentURI: Include only direct replies to this parent post URI. Optional.
+    ///   - threadRootURI: Include only posts in the thread rooted at this post URI. Optional.
+    ///   - excludeReplies: Exclude replies from results. Mutually exclusive with `repliesOnly`. Optional.
+    ///   - repliesOnly: Include only replies. Mutually exclusive with `excludeReplies`. Optional.
+    ///   - following: Include only posts from accounts followed by the viewer. Optional.
+    ///   - queryLanguage: Language analyzer hint for the query text. Optional.
+    ///   - limit: The number of results to return. Optional. Defaults to `25`.
+    ///   Can only choose between `1` and `100`.
+    ///   - cursor: The mark used to indicate the starting point for the next set
+    ///   of results. Optional.
+    ///   - labelersValue: The `atproto-accept-labelers` header value, containing the labeler
+    ///   services whose labels should be applied to the response. Optional.
+    /// - Returns: An array of post records in the results, with an optional cursor to expand
+    /// the array.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func searchPostsV2(
+        matching query: String? = nil,
+        sort: AppBskyLexicon.Feed.SearchPostsV2.SortRanking? = nil,
+        authors: [String]? = nil,
+        mentions: [String]? = nil,
+        domains: [String]? = nil,
+        urls: [String]? = nil,
+        embeddedAtURIs: [String]? = nil,
+        hashtags: [String]? = nil,
+        excludeAuthors: [String]? = nil,
+        excludeMentions: [String]? = nil,
+        excludeDomains: [String]? = nil,
+        excludeURLs: [String]? = nil,
+        excludeEmbeddedAtURIs: [String]? = nil,
+        excludeHashtags: [String]? = nil,
+        since: Date? = nil,
+        until: Date? = nil,
+        allTime: Bool? = nil,
+        languages: [String]? = nil,
+        excludeLanguages: [String]? = nil,
+        hasMedia: Bool? = nil,
+        hasVideo: Bool? = nil,
+        replyParentURI: String? = nil,
+        threadRootURI: String? = nil,
+        excludeReplies: Bool? = nil,
+        repliesOnly: Bool? = nil,
+        following: Bool? = nil,
+        queryLanguage: AppBskyLexicon.Feed.SearchPostsV2.QueryLanguage? = nil,
+        limit: Int? = 25,
+        cursor: String? = nil,
+        labelersValue: String? = nil
+    ) async throws -> AppBskyLexicon.Feed.SearchPostsV2Output {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.feed.searchPostsV2") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        if let query {
+            queryItems.append(("query", query))
+        }
+
+        if let sort {
+            queryItems.append(("sort", sort.rawValue))
+        }
+
+        if let authors {
+            queryItems += authors.map { ("authors", $0) }
+        }
+
+        if let mentions {
+            queryItems += mentions.map { ("mentions", $0) }
+        }
+
+        if let domains {
+            queryItems += domains.map { ("domains", $0) }
+        }
+
+        if let urls {
+            queryItems += urls.map { ("urls", $0) }
+        }
+
+        if let embeddedAtURIs {
+            queryItems += embeddedAtURIs.map { ("embeddedAtUris", $0) }
+        }
+
+        if let hashtags {
+            queryItems += hashtags.map { ("hashtags", $0) }
+        }
+
+        if let excludeAuthors {
+            queryItems += excludeAuthors.map { ("excludeAuthors", $0) }
+        }
+
+        if let excludeMentions {
+            queryItems += excludeMentions.map { ("excludeMentions", $0) }
+        }
+
+        if let excludeDomains {
+            queryItems += excludeDomains.map { ("excludeDomains", $0) }
+        }
+
+        if let excludeURLs {
+            queryItems += excludeURLs.map { ("excludeUrls", $0) }
+        }
+
+        if let excludeEmbeddedAtURIs {
+            queryItems += excludeEmbeddedAtURIs.map { ("excludeEmbeddedAtUris", $0) }
+        }
+
+        if let excludeHashtags {
+            queryItems += excludeHashtags.map { ("excludeHashtags", $0) }
+        }
+
+        if let since, let formattedSince = CustomDateFormatter.shared.string(from: since) {
+            queryItems.append(("since", formattedSince))
+        }
+
+        if let until, let formattedUntil = CustomDateFormatter.shared.string(from: until) {
+            queryItems.append(("until", formattedUntil))
+        }
+
+        if let allTime {
+            queryItems.append(("allTime", "\(allTime)"))
+        }
+
+        if let languages {
+            queryItems += languages.map { ("languages", $0) }
+        }
+
+        if let excludeLanguages {
+            queryItems += excludeLanguages.map { ("excludeLanguages", $0) }
+        }
+
+        if let hasMedia {
+            queryItems.append(("hasMedia", "\(hasMedia)"))
+        }
+
+        if let hasVideo {
+            queryItems.append(("hasVideo", "\(hasVideo)"))
+        }
+
+        if let replyParentURI {
+            queryItems.append(("replyParentUri", replyParentURI))
+        }
+
+        if let threadRootURI {
+            queryItems.append(("threadRootUri", threadRootURI))
+        }
+
+        if let excludeReplies {
+            queryItems.append(("excludeReplies", "\(excludeReplies)"))
+        }
+
+        if let repliesOnly {
+            queryItems.append(("repliesOnly", "\(repliesOnly)"))
+        }
+
+        if let following {
+            queryItems.append(("following", "\(following)"))
+        }
+
+        if let queryLanguage {
+            queryItems.append(("queryLanguage", queryLanguage.rawValue))
+        }
+
+        if let limit {
+            let finalLimit = max(1, min(limit, 100))
+            queryItems.append(("limit", "\(finalLimit)"))
+        }
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true,
+                labelersValue: labelersValue
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: AppBskyLexicon.Feed.SearchPostsV2Output.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetStarterPacksWithMembershipMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetStarterPacksWithMembershipMethod.swift
@@ -1,0 +1,89 @@
+//
+//  AppBskyGraphGetStarterPacksWithMembershipMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-10.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoKit {
+
+    /// Enumerates starter packs created by the session user that includes membership information
+    /// about the specified `actor`.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Enumerates the starter packs created
+    /// by the session user, and includes membership information about `actor` in those starter
+    /// packs. Requires auth."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.graph.getStarterPacksWithMembership`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/graph/getStarterPacksWithMembership.json
+    ///
+    /// - Parameters:
+    ///   - actor: The user account to check membership for in the session user's starter packs.
+    ///   - limit: The number of results to return. Optional. Defaults to `50`.
+    ///   Can only choose between `1` and `100`.
+    ///   - cursor: The mark used to indicate the starting point for the next set
+    ///   of results. Optional.
+    /// - Returns: An array of starter packs with memberships.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getStarterPacksWithMembership(
+        by actor: String,
+        limit: Int? = 50,
+        cursor: String? = nil
+    ) async throws -> AppBskyLexicon.Graph.GetStarterPacksWithMembershipOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        let sessionURL = session.serviceEndpoint.absoluteString
+
+        guard let requestURL = URL(string: "\(sessionURL)/xrpc/app.bsky.graph.getStarterPacksWithMembership") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        queryItems.append(("actor", actor))
+
+        if let limit {
+            let finalLimit = max(1, min(limit, 100))
+            queryItems.append(("limit", "\(finalLimit)"))
+        }
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: AppBskyLexicon.Graph.GetStarterPacksWithMembershipOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGetEmbedExternalView.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGetEmbedExternalView.swift
@@ -1,0 +1,42 @@
+//
+//  AppBskyEmbedGetEmbedExternalView.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-10.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Embed {
+
+    /// An output model for resolving AT-URIs into the data needed to render an enhanced external embed.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Resolve one or more AT-URIs into the
+    /// data needed to render an enhanced external embed."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.embed.getEmbedExternalView`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/getEmbedExternalView.json
+    public struct GetEmbedExternalViewOutput: Sendable, Codable {
+
+        /// The hydrated view of the embed. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Present only when the resolved
+        /// records back the requested URL and supply enough information to populate the required
+        /// `viewExternal` fields."
+        public let view: AppBskyLexicon.Embed.ExternalDefinition.View?
+
+        /// Strong references to the Atmosphere records that backed this view. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "StrongRefs (URI+CID) of the
+        /// Atmosphere records that backed this view, suitable for embedding into a post's
+        /// external.associatedRefs."
+        public let associatedRefs: [ComAtprotoLexicon.Repository.StrongReference]?
+
+        /// The raw record data of the Atmosphere records that backed this view. Optional.
+        public let associatedRecords: [[String: CodableValue]]?
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedSearchPostsV2.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedSearchPostsV2.swift
@@ -1,0 +1,136 @@
+//
+//  AppBskyFeedSearchPostsV2.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-10.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Feed {
+
+    /// The main data model definition for the results of the v2 post search query.
+    public struct SearchPostsV2: Sendable, Codable {
+
+        /// Determines the ranking order for the search results.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Ranking order for results."
+        ///
+        /// - SeeAlso: This is based on the [`app.bsky.feed.searchPostsV2`][github] lexicon.
+        ///
+        /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/feed/searchPostsV2.json
+        public enum SortRanking: String, Sendable, Codable {
+
+            /// Indicates the results will be sorted by recency.
+            case recent
+
+            /// Indicates the results will be sorted by search ranking.
+            case top
+        }
+
+        /// The language analyzer hint for query text processing.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Language analyzer hint for the
+        /// query text. If unset, the server auto-detects when possible."
+        ///
+        /// - SeeAlso: This is based on the [`app.bsky.feed.searchPostsV2`][github] lexicon.
+        ///
+        /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/feed/searchPostsV2.json
+        public enum QueryLanguage: Sendable, Codable, ExpressibleByStringLiteral {
+
+            /// Japanese.
+            case japanese
+
+            /// Chinese.
+            case chinese
+
+            /// Korean.
+            case korean
+
+            /// Thai.
+            case thai
+
+            /// Arabic.
+            case arabic
+
+            /// An unknown value that the object may contain.
+            case unknown(String)
+
+            public var rawValue: String {
+                switch self {
+                    case .japanese:
+                        return "ja"
+                    case .chinese:
+                        return "zh"
+                    case .korean:
+                        return "ko"
+                    case .thai:
+                        return "th"
+                    case .arabic:
+                        return "ar"
+                    case .unknown(let value):
+                        return value
+                }
+            }
+
+            public init(stringLiteral value: String) {
+                self = .unknown(value)
+            }
+
+            public init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                let value = try container.decode(String.self)
+
+                switch value {
+                    case "ja":
+                        self = .japanese
+                    case "zh":
+                        self = .chinese
+                    case "ko":
+                        self = .korean
+                    case "th":
+                        self = .thai
+                    case "ar":
+                        self = .arabic
+                    default:
+                        self = .unknown(value)
+                }
+            }
+
+            public func encode(to encoder: Encoder) throws {
+                var container = encoder.singleValueContainer()
+                try container.encode(self.rawValue)
+            }
+        }
+    }
+
+    /// An output model for the results of the v2 post search query.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Find posts matching a search query
+    /// or filters, returning search hits for matching post records."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.feed.searchPostsV2`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/feed/searchPostsV2.json
+    public struct SearchPostsV2Output: Sendable, Codable {
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+
+        /// Estimated total number of matching hits. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "May be rounded or truncated."
+        public let hitsTotal: Int?
+
+        /// Hydrated views of matching posts.
+        public let posts: [PostViewDefinition]
+
+        /// Query languages detected for CJK, Thai, or Arabic text. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Empty or omitted for other scripts."
+        public let detectedQueryLanguages: [AppBskyLexicon.Feed.SearchPostsV2.QueryLanguage]?
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Graph/AppBskyGraphGetStarterPacksWithMembership.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Graph/AppBskyGraphGetStarterPacksWithMembership.swift
@@ -1,0 +1,63 @@
+//
+//  AppBskyGraphGetStarterPacksWithMembership.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-10.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension AppBskyLexicon.Graph {
+
+    /// A definition model for enumerating starter packs created by the session user that includes
+    /// membership information about the specified `actor`.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Enumerates the starter packs created
+    /// by the session user, and includes membership information about `actor` in those starter
+    /// packs. Requires auth."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.graph.getStarterPacksWithMembership`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/graph/getStarterPacksWithMembership.json
+    public struct GetStarterPacksWithMembership: Sendable, Codable {
+
+        /// A starter pack with an optional membership of a target user account.
+        ///
+        /// - Note: According to the AT Protocol specifications: "A starter pack and an optional
+        /// list item indicating membership of a target user to that starter pack."
+        ///
+        /// - SeeAlso: This is based on the [`app.bsky.graph.getStarterPacksWithMembership`][github] lexicon.
+        ///
+        /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/graph/getStarterPacksWithMembership.json
+        public struct StarterPackWithMembership: Sendable, Codable {
+
+            /// The starter pack itself.
+            public let starterPack: AppBskyLexicon.Graph.StarterPackViewDefinition
+
+            /// The membership of the target user account to that starter pack's list. Optional.
+            public let listItem: AppBskyLexicon.Graph.ListItemViewDefinition?
+        }
+    }
+
+    /// An output model for enumerating starter packs created by the session user that includes
+    /// membership information about the specified `actor`.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Enumerates the starter packs created
+    /// by the session user, and includes membership information about `actor` in those starter
+    /// packs. Requires auth."
+    ///
+    /// - SeeAlso: This is based on the [`app.bsky.graph.getStarterPacksWithMembership`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/graph/getStarterPacksWithMembership.json
+    public struct GetStarterPacksWithMembershipOutput: Sendable, Codable {
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+
+        /// An array of starter packs with membership.
+        public let starterPacksWithMembership: [AppBskyLexicon.Graph.GetStarterPacksWithMembership.StarterPackWithMembership]
+    }
+}


### PR DESCRIPTION
## Description
Adds typed support for three missing App View queries. Each is a stable, single-endpoint sibling of an already-wrapped surface.

### Added files
- `Sources/ATProtoKit/Models/Lexicons/app.bsky/Embed/AppBskyEmbedGetEmbedExternalView.swift`
- `Sources/ATProtoKit/Models/Lexicons/app.bsky/Feed/AppBskyFeedSearchPostsV2.swift`
- `Sources/ATProtoKit/Models/Lexicons/app.bsky/Graph/AppBskyGraphGetStarterPacksWithMembership.swift`
- `Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyEmbedGetEmbedExternalViewMethod.swift`
- `Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyFeedSearchPostsV2Method.swift`
- `Sources/ATProtoKit/APIReference/AppBskyAPI/AppBskyGraphGetStarterPacksWithMembershipMethod.swift`

### New methods
- `getEmbedExternalView(url:uris:)` — resolves AT-URIs into the data needed to render an enhanced external embed; `uris` is capped at 4 items client-side per the lexicon
- `searchPostsV2(matching:...)` — the v2 successor to `searchPosts(matching:...)`, covering the full filter set (authors, mentions, domains, URLs, embedded AT-URIs, hashtags, their exclusion counterparts, date ranges, languages, media/video, reply scoping, and following)
- `getStarterPacksWithMembership(by:limit:cursor:)` — the Starter Pack counterpart to `getListsWithMembership(by:limit:cursor:)`, with the same shape

`QueryLanguage` is implemented as an open enum with an `unknown(String)` case so that decoding does not fail if the server returns a language code outside the currently documented set (ja/zh/ko/th/ar).

## Linked Issues
#315

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
This implementation serves as an interim typed layer for these three queries until ATLexiconC covers them. If this PR is useful before ATLexiconC lands, feel free to merge it; if ATLexiconC will supersede it, feel free to close without merging — no pressure either way.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
