### PR TITLE
Add tools.ozone.queue and tools.ozone.report namespace support

### DIFF
--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueAssignModeratorMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueAssignModeratorMethod.swift
@@ -1,0 +1,67 @@
+//
+//  ToolsOzoneQueueAssignModeratorMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Assigns a moderator to a queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Assign a user to a queue."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.assignModerator`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/assignModerator.json
+    ///
+    /// - Parameters:
+    ///   - did: The decentralized identifier (DID) of the moderator to assign.
+    ///   - queueID: The ID of the queue to assign the moderator to.
+    /// - Returns: The queue assignment view.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func assignModeratorToQueue(
+        _ did: String,
+        queueID: Int
+    ) async throws -> ToolsOzoneLexicon.Queue.QueueAssignmentViewDefinition {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.queue.assignModerator") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ToolsOzoneLexicon.Queue.AssignModeratorRequestBody(
+            queueID: queueID,
+            did: did
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: ToolsOzoneLexicon.Queue.QueueAssignmentViewDefinition.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueCreateQueueMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueCreateQueueMethod.swift
@@ -1,0 +1,82 @@
+//
+//  ToolsOzoneQueueCreateQueueMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Creates a new moderation queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Create a new moderation queue. A queue
+    /// can have optional matching criteria that ozone's queue router will use to match reports. A
+    /// queue with no criteria must have reports assigned to it manually via (1) `modTool.meta.queueId`
+    /// in `tools.ozone.moderation.emitEvent` or (2) `tools.ozone.report.reassignQueue`."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.createQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/createQueue.json
+    ///
+    /// - Parameters:
+    ///   - name: The display name for the queue.
+    ///   - subjectTypes: Subject types this queue accepts. Optional.
+    ///   - collection: Collection name for record subjects. Optional.
+    ///   - reportTypes: Report reason types for this queue. Optional.
+    ///   - description: A description of the queue. Optional.
+    ///   - recommendedPolicies: Recommended policy keys for actioning reports in this queue. Optional.
+    /// - Returns: The newly created moderation queue.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func createModerationQueue(
+        name: String,
+        subjectTypes: [String]? = nil,
+        collection: String? = nil,
+        reportTypes: [String]? = nil,
+        description: String? = nil,
+        recommendedPolicies: [String]? = nil
+    ) async throws -> ToolsOzoneLexicon.Queue.CreateQueueOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.queue.createQueue") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ToolsOzoneLexicon.Queue.CreateQueueRequestBody(
+            name: name,
+            subjectTypes: subjectTypes,
+            collection: collection,
+            reportTypes: reportTypes,
+            description: description,
+            recommendedPolicies: recommendedPolicies
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: ToolsOzoneLexicon.Queue.CreateQueueOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueDeleteQueueMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueDeleteQueueMethod.swift
@@ -1,0 +1,69 @@
+//
+//  ToolsOzoneQueueDeleteQueueMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Deletes a moderation queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Delete a moderation queue.
+    /// Optionally migrate reports to another queue."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.deleteQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/deleteQueue.json
+    ///
+    /// - Parameters:
+    ///   - queueID: The ID of the queue to delete.
+    ///   - migrateToQueueID: The ID of a queue to migrate reports to. Optional.
+    /// - Returns: The deletion result, including whether deletion succeeded and how many
+    /// reports were migrated.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func deleteModerationQueue(
+        by queueID: Int,
+        migrateToQueueID: Int? = nil
+    ) async throws -> ToolsOzoneLexicon.Queue.DeleteQueueOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.queue.deleteQueue") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ToolsOzoneLexicon.Queue.DeleteQueueRequestBody(
+            queueID: queueID,
+            migrateToQueueID: migrateToQueueID
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: ToolsOzoneLexicon.Queue.DeleteQueueOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueGetAssignmentsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueGetAssignmentsMethod.swift
@@ -1,0 +1,96 @@
+//
+//  ToolsOzoneQueueGetAssignmentsMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Gets moderator assignments for queues.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get moderator assignments, optionally
+    /// filtered by active status, queue, or moderator."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.getAssignments`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/getAssignments.json
+    ///
+    /// - Parameters:
+    ///   - onlyActive: When `true`, only returns active assignments. Optional. Defaults to `true`.
+    ///   - queueIDs: Filter assignments to specific queues. Optional.
+    ///   - dids: Filter assignments to specific moderators. Optional.
+    ///   - limit: The number of assignments in the array. Optional. Defaults to `50`.
+    ///   - cursor: The mark used to indicate the starting point for the next set of
+    ///   results. Optional.
+    /// - Returns: An array of queue moderator assignments, with an optional cursor to extend
+    /// the array.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getQueueAssignments(
+        onlyActive: Bool = true,
+        queueIDs: [Int]? = nil,
+        dids: [String]? = nil,
+        limit: Int = 50,
+        cursor: String? = nil
+    ) async throws -> ToolsOzoneLexicon.Queue.GetAssignmentsOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.queue.getAssignments") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        queryItems.append(("onlyActive", "\(onlyActive)"))
+
+        if let queueIDs {
+            queryItems += queueIDs.map { ("queueIds", "\($0)") }
+        }
+
+        if let dids {
+            queryItems += dids.map { ("dids", $0) }
+        }
+
+        let finalLimit = max(1, min(limit, 100))
+        queryItems.append(("limit", "\(finalLimit)"))
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: ToolsOzoneLexicon.Queue.GetAssignmentsOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueListQueuesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueListQueuesMethod.swift
@@ -1,0 +1,105 @@
+//
+//  ToolsOzoneQueueListQueuesMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Lists all configured moderation queues with statistics.
+    ///
+    /// - Note: According to the AT Protocol specifications: "List all configured moderation
+    /// queues with statistics."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.listQueues`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/listQueues.json
+    ///
+    /// - Parameters:
+    ///   - isEnabled: Filter by enabled status. Optional.
+    ///   - subjectType: Filter queues that handle this subject type. Optional.
+    ///   - collection: Filter queues by collection name. Optional.
+    ///   - reportTypes: Filter queues that handle any of these report reason types. Optional.
+    ///   - limit: The number of queues in the array. Optional. Defaults to `50`.
+    ///   - cursor: The mark used to indicate the starting point for the next set of
+    ///   results. Optional.
+    /// - Returns: An array of moderation queues based on the given filters, with an optional
+    /// cursor to extend the array.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func listModerationQueues(
+        isEnabled: Bool? = nil,
+        subjectType: String? = nil,
+        collection: String? = nil,
+        reportTypes: [String]? = nil,
+        limit: Int = 50,
+        cursor: String? = nil
+    ) async throws -> ToolsOzoneLexicon.Queue.ListQueuesOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.queue.listQueues") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        if let isEnabled {
+            queryItems.append(("enabled", "\(isEnabled)"))
+        }
+
+        if let subjectType {
+            queryItems.append(("subjectType", subjectType))
+        }
+
+        if let collection {
+            queryItems.append(("collection", collection))
+        }
+
+        if let reportTypes {
+            let cappedReportTypes = reportTypes.prefix(10)
+            queryItems += cappedReportTypes.map { ("reportTypes", $0) }
+        }
+
+        let finalLimit = max(1, min(limit, 100))
+        queryItems.append(("limit", "\(finalLimit)"))
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: ToolsOzoneLexicon.Queue.ListQueuesOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueRouteReportsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueRouteReportsMethod.swift
@@ -1,0 +1,67 @@
+//
+//  ToolsOzoneQueueRouteReportsMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Routes reports within an ID range to matching queues.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Route reports within an ID range to
+    /// matching queues based."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.routeReports`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/routeReports.json
+    ///
+    /// - Parameters:
+    ///   - reportIDs: A range of report IDs. The first value is the start (inclusive) and the
+    ///   second is the end (inclusive). The difference must be less than 5,000.
+    /// - Returns: The number of reports assigned to a queue and the number of unmatched reports.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func routeReportsToQueue(
+        _ reportIDs: ClosedRange<Int>
+    ) async throws -> ToolsOzoneLexicon.Queue.RouteReportsOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.queue.routeReports") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ToolsOzoneLexicon.Queue.RouteReportsRequestBody(
+            startReportID: reportIDs.lowerBound,
+            endReportID: reportIDs.upperBound
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: ToolsOzoneLexicon.Queue.RouteReportsOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueUnassignModeratorMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueUnassignModeratorMethod.swift
@@ -1,0 +1,61 @@
+//
+//  ToolsOzoneQueueUnassignModeratorMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Removes a moderator's assignment from a queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Remove a user's assignment
+    /// from a queue."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.unassignModerator`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/unassignModerator.json
+    ///
+    /// - Parameters:
+    ///   - did: The decentralized identifier (DID) of the moderator to unassign.
+    ///   - queueID: The ID of the queue to unassign the moderator from.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func unassignModeratorFromQueue(
+        _ did: String,
+        queueID: Int
+    ) async throws {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.queue.unassignModerator") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ToolsOzoneLexicon.Queue.UnassignModeratorRequestBody(
+            queueID: queueID,
+            did: did
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: nil,
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            _ = try await apiClientService.sendRequest(request, withEncodingBody: requestBody)
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueUpdateQueueMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueUpdateQueueMethod.swift
@@ -1,0 +1,76 @@
+//
+//  ToolsOzoneQueueUpdateQueueMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Updates the properties of a moderation queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Update queue properties."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.updateQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/updateQueue.json
+    ///
+    /// - Parameters:
+    ///   - queueID: The ID of the queue to update.
+    ///   - name: A new display name for the queue. Optional.
+    ///   - isEnabled: Whether the queue is enabled. Optional.
+    ///   - description: A description of the queue. Optional.
+    ///   - recommendedPolicies: Recommended policy keys for actioning reports in this queue. Optional.
+    /// - Returns: The updated moderation queue.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func updateModerationQueue(
+        by queueID: Int,
+        name: String? = nil,
+        isEnabled: Bool? = nil,
+        description: String? = nil,
+        recommendedPolicies: [String]? = nil
+    ) async throws -> ToolsOzoneLexicon.Queue.UpdateQueueOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.queue.updateQueue") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ToolsOzoneLexicon.Queue.UpdateQueueRequestBody(
+            queueID: queueID,
+            name: name,
+            isEnabled: isEnabled,
+            description: description,
+            recommendedPolicies: recommendedPolicies
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: ToolsOzoneLexicon.Queue.UpdateQueueOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportAssignModeratorMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportAssignModeratorMethod.swift
@@ -1,0 +1,74 @@
+//
+//  ToolsOzoneReportAssignModeratorMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Assigns a moderator to a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Assign a report to a user. Defaults
+    /// to the caller. Admins may assign to any moderator."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.assignModerator`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/assignModerator.json
+    ///
+    /// - Parameters:
+    ///   - did: The decentralized identifier (DID) of the moderator to assign. Optional.
+    ///   - reportID: The ID of the report to assign.
+    ///   - queueID: An optional queue ID to associate the assignment with. Optional.
+    ///   - isPermanent: Whether the assignment has no expiry. Optional.
+    /// - Returns: The report assignment view.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func assignModeratorToReport(
+        _ did: String? = nil,
+        reportID: Int,
+        queueID: Int? = nil,
+        isPermanent: Bool? = nil
+    ) async throws -> ToolsOzoneLexicon.Report.ReportAssignmentViewDefinition {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.assignModerator") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ToolsOzoneLexicon.Report.AssignModeratorRequestBody(
+            reportID: reportID,
+            queueID: queueID,
+            did: did,
+            isPermanent: isPermanent
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: ToolsOzoneLexicon.Report.ReportAssignmentViewDefinition.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportCloseReportsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportCloseReportsMethod.swift
@@ -1,0 +1,79 @@
+//
+//  ToolsOzoneReportCloseReportsMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Closes all reports on a subject matching the given criteria.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Close all reports on a subject
+    /// matching the given criteria. Reports whose current status does not permit a transition
+    /// to closed are skipped silently. Intended for automated flows that resolve reports
+    /// without taking action on the subject."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.closeReports`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/closeReports.json
+    ///
+    /// - Parameters:
+    ///   - subject: The subject whose reports should be closed. Can be a decentralized
+    ///   identifier (DID) for account-level reports or an AT-URI for record-level reports.
+    ///   - reportTypes: A filter of report types (fully qualified reason NSIDs) to close.
+    ///   Optional. When omitted, all non-closed reports on the subject are targeted.
+    ///   - internalNote: A moderator-only note recorded on each close activity. Optional.
+    ///   - isAutomated: Determines whether this action is triggered by an automated process.
+    ///   Optional. Defaults to `false`.
+    /// - Returns: The number of closed reports, as well as an array of their IDs.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func closeReports(
+        subject: String,
+        reportTypes: [String]? = nil,
+        internalNote: String? = nil,
+        isAutomated: Bool? = nil
+    ) async throws -> ToolsOzoneLexicon.Report.CloseReportsOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.closeReports") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ToolsOzoneLexicon.Report.CloseReportsRequestBody(
+            subject: subject,
+            reportTypes: reportTypes,
+            internalNote: internalNote,
+            isAutomated: isAutomated
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: ToolsOzoneLexicon.Report.CloseReportsOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportCreateActivityMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportCreateActivityMethod.swift
@@ -1,0 +1,80 @@
+//
+//  ToolsOzoneReportCreateActivityMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Registers an activity on a moderation report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Register an activity on a report. For
+    /// state-change activity types, validates the transition and updates report.status atomically."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.createActivity`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/createActivity.json
+    ///
+    /// - Parameters:
+    ///   - activity: The type of activity to record.
+    ///   - reportID: The ID of the report to record activity on. Optional.
+    ///   - eventID: The ID of the report moderation event. Optional.
+    ///   - internalNote: An optional moderator-only note. Optional.
+    ///   - publicNote: An optional public-facing note. Optional.
+    ///   - isAutomated: Whether this activity is triggered by an automated process. Optional.
+    /// - Returns: The recorded activity view.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func createReportActivity(
+        _ activity: ToolsOzoneLexicon.Report.ActivityUnion,
+        reportID: Int? = nil,
+        eventID: Int? = nil,
+        internalNote: String? = nil,
+        publicNote: String? = nil,
+        isAutomated: Bool? = nil
+    ) async throws -> ToolsOzoneLexicon.Report.CreateActivityOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.createActivity") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ToolsOzoneLexicon.Report.CreateActivityRequestBody(
+            reportID: reportID,
+            eventID: eventID,
+            activity: activity,
+            internalNote: internalNote,
+            publicNote: publicNote,
+            isAutomated: isAutomated
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: ToolsOzoneLexicon.Report.CreateActivityOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetAssignmentsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetAssignmentsMethod.swift
@@ -1,0 +1,97 @@
+//
+//  ToolsOzoneReportGetAssignmentsMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Gets assignments for reports.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get assignments for reports."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.getAssignments`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/getAssignments.json
+    ///
+    /// - Parameters:
+    ///   - onlyActive: When `true`, only returns active assignments. Optional. Defaults to `true`.
+    ///   - reportIDs: Filter assignments to specific reports. Optional.
+    ///   - dids: Filter assignments to specific moderators. Optional.
+    ///   - limit: The number of assignments in the array. Optional. Defaults to `50`.
+    ///   - cursor: The mark used to indicate the starting point for the next set of
+    ///   results. Optional.
+    /// - Returns: An array of report moderator assignments, with an optional cursor to extend
+    /// the array.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getReportAssignments(
+        onlyActive: Bool = true,
+        reportIDs: [Int]? = nil,
+        dids: [String]? = nil,
+        limit: Int = 50,
+        cursor: String? = nil
+    ) async throws -> ToolsOzoneLexicon.Report.GetAssignmentsOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.getAssignments") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        queryItems.append(("onlyActive", "\(onlyActive)"))
+
+        if let reportIDs {
+            let cappedReportIDs = reportIDs.prefix(50)
+            queryItems += cappedReportIDs.map { ("reportIds", "\($0)") }
+        }
+
+        if let dids {
+            let cappedDIDs = dids.prefix(50)
+            queryItems += cappedDIDs.map { ("dids", $0) }
+        }
+
+        let finalLimit = max(1, min(limit, 100))
+        queryItems.append(("limit", "\(finalLimit)"))
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: ToolsOzoneLexicon.Report.GetAssignmentsOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetHistoricalStatsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetHistoricalStatsMethod.swift
@@ -1,0 +1,111 @@
+//
+//  ToolsOzoneReportGetHistoricalStatsMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Gets historical daily report statistics.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get historical daily report statistics.
+    /// Returns a paginated list of daily stat snapshots, newest first. Filter by queue, moderator,
+    /// or report type."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.getHistoricalStats`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/getHistoricalStats.json
+    ///
+    /// - Parameters:
+    ///   - queueID: Filter stats by queue. Use `-1` for unqueued reports. Optional.
+    ///   - moderatorDID: Filter stats by moderator DID. Optional.
+    ///   - reportTypes: Filter stats by report types. Optional.
+    ///   - startDate: The earliest date to include (inclusive). Optional.
+    ///   - endDate: The latest date to include (inclusive). Optional.
+    ///   - limit: The maximum number of entries to return. Optional. Defaults to `30`.
+    ///   - cursor: The mark used to indicate the starting point for the next set of
+    ///   results. Optional.
+    /// - Returns: An array of daily historical statistics snapshots, with an optional cursor
+    /// to extend the array.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getHistoricalReportStats(
+        queueID: Int? = nil,
+        moderatorDID: String? = nil,
+        reportTypes: [String]? = nil,
+        startDate: Date? = nil,
+        endDate: Date? = nil,
+        limit: Int = 30,
+        cursor: String? = nil
+    ) async throws -> ToolsOzoneLexicon.Report.GetHistoricalStatsOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.getHistoricalStats") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        if let queueID {
+            queryItems.append(("queueId", "\(queueID)"))
+        }
+
+        if let moderatorDID {
+            queryItems.append(("moderatorDid", moderatorDID))
+        }
+
+        if let reportTypes {
+            queryItems += reportTypes.map { ("reportTypes", $0) }
+        }
+
+        if let startDate, let formatted = CustomDateFormatter.shared.string(from: startDate) {
+            queryItems.append(("startDate", formatted))
+        }
+
+        if let endDate, let formatted = CustomDateFormatter.shared.string(from: endDate) {
+            queryItems.append(("endDate", formatted))
+        }
+
+        let finalLimit = max(1, min(limit, 100))
+        queryItems.append(("limit", "\(finalLimit)"))
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: ToolsOzoneLexicon.Report.GetHistoricalStatsOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetLatestReportMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetLatestReportMethod.swift
@@ -1,0 +1,55 @@
+//
+//  ToolsOzoneReportGetLatestReportMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Gets the most recent moderation report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get the most recent report."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.getLatestReport`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/getLatestReport.json
+    ///
+    /// - Returns: The most recent moderation report.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getLatestReport() async throws -> ToolsOzoneLexicon.Report.GetLatestReportOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.getLatestReport") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: ToolsOzoneLexicon.Report.GetLatestReportOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetLiveStatsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetLiveStatsMethod.swift
@@ -1,0 +1,86 @@
+//
+//  ToolsOzoneReportGetLiveStatsMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Gets live report statistics from the past 24 hours.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get live report statistics from the
+    /// past 24 hours. Filter by queue, moderator, or report type. Omit all parameters for
+    /// aggregate stats."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.getLiveStats`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/getLiveStats.json
+    ///
+    /// - Parameters:
+    ///   - queueID: Filter stats by queue. Use `-1` for unqueued reports. Optional.
+    ///   - moderatorDID: Filter stats by moderator DID. Optional.
+    ///   - reportTypes: Filter stats by report types. Optional.
+    /// - Returns: Live report statistics for the requested filter.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getLiveReportStats(
+        queueID: Int? = nil,
+        moderatorDID: String? = nil,
+        reportTypes: [String]? = nil
+    ) async throws -> ToolsOzoneLexicon.Report.GetLiveStatsOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.getLiveStats") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        if let queueID {
+            queryItems.append(("queueId", "\(queueID)"))
+        }
+
+        if let moderatorDID {
+            queryItems.append(("moderatorDid", moderatorDID))
+        }
+
+        if let reportTypes {
+            queryItems += reportTypes.map { ("reportTypes", $0) }
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: ToolsOzoneLexicon.Report.GetLiveStatsOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetReportMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetReportMethod.swift
@@ -1,0 +1,69 @@
+//
+//  ToolsOzoneReportGetReportMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Gets details about a single moderation report by ID.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get details about a single moderation
+    /// report by ID."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.getReport`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/getReport.json
+    ///
+    /// - Parameter id: The ID of the report to retrieve.
+    /// - Returns: The moderation report view.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func getReport(
+        by id: Int
+    ) async throws -> ToolsOzoneLexicon.Report.ReportViewDefinition {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.getReport") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+        queryItems.append(("id", "\(id)"))
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: ToolsOzoneLexicon.Report.ReportViewDefinition.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportListActivitiesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportListActivitiesMethod.swift
@@ -1,0 +1,83 @@
+//
+//  ToolsOzoneReportListActivitiesMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Lists all activities for a moderation report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "List all activities for a report,
+    /// sorted most-recent-first."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.listActivities`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/listActivities.json
+    ///
+    /// - Parameters:
+    ///   - reportID: The ID of the report whose activities to list.
+    ///   - limit: The number of activities in the array. Optional. Defaults to `50`.
+    ///   - cursor: The mark used to indicate the starting point for the next set of
+    ///   results. Optional.
+    /// - Returns: An array of report activities, with an optional cursor to extend the array.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func listReportActivities(
+        reportID: Int,
+        limit: Int = 50,
+        cursor: String? = nil
+    ) async throws -> ToolsOzoneLexicon.Report.ListActivitiesOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.listActivities") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        queryItems.append(("reportId", "\(reportID)"))
+
+        let finalLimit = max(1, min(limit, 100))
+        queryItems.append(("limit", "\(finalLimit)"))
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: ToolsOzoneLexicon.Report.ListActivitiesOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportQueryActivitiesMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportQueryActivitiesMethod.swift
@@ -1,0 +1,104 @@
+//
+//  ToolsOzoneReportQueryActivitiesMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Queries report activities across all reports.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Query report activities across all
+    /// reports, ordered by createdAt. Used by downstream pollers; for per-report activity history
+    /// use listActivities."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.queryActivities`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/queryActivities.json
+    ///
+    /// - Parameters:
+    ///   - activityTypes: Filter to specific activity types. Optional.
+    ///   - createdAfter: Retrieve activities created at or after a given timestamp. Optional.
+    ///   - createdBefore: Retrieve activities created at or before a given timestamp. Optional.
+    ///   - sortDirection: The direction to sort results. Optional. Defaults to `.descending`.
+    ///   - limit: The number of activities in the array. Optional. Defaults to `50`.
+    ///   - cursor: The mark used to indicate the starting point for the next set of
+    ///   results. Optional.
+    /// - Returns: An array of report activities, with an optional cursor to extend the array.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func queryReportActivities(
+        activityTypes: [String]? = nil,
+        createdAfter: Date? = nil,
+        createdBefore: Date? = nil,
+        sortDirection: ToolsOzoneLexicon.Report.QueryActivities.SortDirection? = .descending,
+        limit: Int = 50,
+        cursor: String? = nil
+    ) async throws -> ToolsOzoneLexicon.Report.QueryActivitiesOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.queryActivities") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        if let activityTypes {
+            queryItems += activityTypes.map { ("activityTypes", $0) }
+        }
+
+        if let createdAfter, let formatted = CustomDateFormatter.shared.string(from: createdAfter) {
+            queryItems.append(("createdAfter", formatted))
+        }
+
+        if let createdBefore, let formatted = CustomDateFormatter.shared.string(from: createdBefore) {
+            queryItems.append(("createdBefore", formatted))
+        }
+
+        if let sortDirection {
+            queryItems.append(("sortDirection", sortDirection.rawValue))
+        }
+
+        let finalLimit = max(1, min(limit, 100))
+        queryItems.append(("limit", "\(finalLimit)"))
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: ToolsOzoneLexicon.Report.QueryActivitiesOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportQueryReportsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportQueryReportsMethod.swift
@@ -1,0 +1,158 @@
+//
+//  ToolsOzoneReportQueryReportsMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Queries moderation reports.
+    ///
+    /// - Note: According to the AT Protocol specifications: "View moderation reports. Reports are
+    /// individual instances of content being reported, as opposed to subject statuses which
+    /// aggregate reports at the subject level."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.queryReports`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/queryReports.json
+    ///
+    /// - Parameters:
+    ///   - status: Filter by report status.
+    ///   - queueID: Filter by queue ID. Use `-1` for unassigned reports. Optional.
+    ///   - reportTypes: Filter by report types. Optional.
+    ///   - subject: Filter by subject DID or AT-URI. Optional.
+    ///   - did: Filter by the DID of the subject account. Optional.
+    ///   - subjectType: Filter by subject type. Optional.
+    ///   - collections: Filter by collections. Optional.
+    ///   - reportedAfter: Filter to reports created after a given timestamp. Optional.
+    ///   - reportedBefore: Filter to reports created before a given timestamp. Optional.
+    ///   - isMuted: Filter by muted status. Optional.
+    ///   - assignedTo: Filter by the DID of the assigned moderator. Optional.
+    ///   - sortField: The field to sort results by. Optional. Defaults to `.createdAt`.
+    ///   - sortDirection: The direction to sort results. Optional. Defaults to `.descending`.
+    ///   - limit: The number of reports in the array. Optional. Defaults to `50`.
+    ///   - cursor: The mark used to indicate the starting point for the next set of
+    ///   results. Optional.
+    /// - Returns: An array of moderation reports based on the given filters, with an optional
+    /// cursor to extend the array.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func queryReports(
+        status: ToolsOzoneLexicon.Report.ReportStatus,
+        queueID: Int? = nil,
+        reportTypes: [String]? = nil,
+        subject: String? = nil,
+        did: String? = nil,
+        subjectType: String? = nil,
+        collections: [String]? = nil,
+        reportedAfter: Date? = nil,
+        reportedBefore: Date? = nil,
+        isMuted: Bool? = nil,
+        assignedTo: String? = nil,
+        sortField: ToolsOzoneLexicon.Report.QueryReports.SortField? = .createdAt,
+        sortDirection: ToolsOzoneLexicon.Report.QueryReports.SortDirection? = .descending,
+        limit: Int = 50,
+        cursor: String? = nil
+    ) async throws -> ToolsOzoneLexicon.Report.QueryReportsOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.queryReports") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        var queryItems = [(String, String)]()
+
+        queryItems.append(("status", status.rawValue))
+
+        if let queueID {
+            queryItems.append(("queueId", "\(queueID)"))
+        }
+
+        if let reportTypes {
+            queryItems += reportTypes.map { ("reportTypes", $0) }
+        }
+
+        if let subject {
+            queryItems.append(("subject", subject))
+        }
+
+        if let did {
+            queryItems.append(("did", did))
+        }
+
+        if let subjectType {
+            queryItems.append(("subjectType", subjectType))
+        }
+
+        if let collections {
+            let cappedCollections = collections.prefix(20)
+            queryItems += cappedCollections.map { ("collections", $0) }
+        }
+
+        if let reportedAfter, let formatted = CustomDateFormatter.shared.string(from: reportedAfter) {
+            queryItems.append(("reportedAfter", formatted))
+        }
+
+        if let reportedBefore, let formatted = CustomDateFormatter.shared.string(from: reportedBefore) {
+            queryItems.append(("reportedBefore", formatted))
+        }
+
+        if let isMuted {
+            queryItems.append(("isMuted", "\(isMuted)"))
+        }
+
+        if let assignedTo {
+            queryItems.append(("assignedTo", assignedTo))
+        }
+
+        if let sortField {
+            queryItems.append(("sortField", sortField.rawValue))
+        }
+
+        if let sortDirection {
+            queryItems.append(("sortDirection", sortDirection.rawValue))
+        }
+
+        let finalLimit = max(1, min(limit, 100))
+        queryItems.append(("limit", "\(finalLimit)"))
+
+        if let cursor {
+            queryItems.append(("cursor", cursor))
+        }
+
+        let queryURL: URL
+
+        do {
+            queryURL = try apiClientService.setQueryItems(
+                for: requestURL,
+                with: queryItems
+            )
+
+            let request = apiClientService.createRequest(
+                forRequest: queryURL,
+                andMethod: .get,
+                acceptValue: "application/json",
+                contentTypeValue: nil,
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                decodeTo: ToolsOzoneLexicon.Report.QueryReportsOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportReassignQueueMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportReassignQueueMethod.swift
@@ -1,0 +1,71 @@
+//
+//  ToolsOzoneReportReassignQueueMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Reassigns a moderation report to a different queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Manually reassign a report to a
+    /// different queue (or unassign it). Records a queueActivity entry on the report."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.reassignQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/reassignQueue.json
+    ///
+    /// - Parameters:
+    ///   - reportID: The ID of the report to reassign.
+    ///   - queueID: The target queue ID. Use `-1` to unassign from any queue.
+    ///   - comment: An optional moderator-only note. Optional.
+    /// - Returns: The updated moderation report.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func reassignReportQueue(
+        reportID: Int,
+        queueID: Int,
+        comment: String? = nil
+    ) async throws -> ToolsOzoneLexicon.Report.ReassignQueueOutput {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.reassignQueue") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ToolsOzoneLexicon.Report.ReassignQueueRequestBody(
+            reportID: reportID,
+            queueID: queueID,
+            comment: comment
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: ToolsOzoneLexicon.Report.ReassignQueueOutput.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportRefreshStatsMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportRefreshStatsMethod.swift
@@ -1,0 +1,69 @@
+//
+//  ToolsOzoneReportRefreshStatsMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Recomputes report statistics for a date range.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Recompute report statistics for a
+    /// date range. Useful for backfilling after failures or data corrections."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.refreshStats`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/refreshStats.json
+    ///
+    /// - Parameters:
+    ///   - startDate: The start date for recomputation, inclusive (YYYY-MM-DD).
+    ///   - endDate: The end date for recomputation, inclusive (YYYY-MM-DD).
+    ///   - queueIDs: An optional list of queue IDs to recompute. Optional.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func refreshReportStats(
+        startDate: Date,
+        endDate: Date,
+        queueIDs: [Int]? = nil
+    ) async throws {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.refreshStats") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+
+        let requestBody = ToolsOzoneLexicon.Report.RefreshStatsRequestBody(
+            startDate: dateFormatter.string(from: startDate),
+            endDate: dateFormatter.string(from: endDate),
+            queueIDs: queueIDs
+        )
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: nil,
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            _ = try await apiClientService.sendRequest(request, withEncodingBody: requestBody)
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportUnassignModeratorMethod.swift
+++ b/Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportUnassignModeratorMethod.swift
@@ -1,0 +1,61 @@
+//
+//  ToolsOzoneReportUnassignModeratorMethod.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ATProtoAdmin {
+
+    /// Removes a report assignment.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Remove report assignment."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.unassignModerator`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/unassignModerator.json
+    ///
+    /// - Parameter reportID: The ID of the report to unassign.
+    /// - Returns: The updated report assignment view.
+    ///
+    /// - Throws: An ``ATProtoError``-conforming error type, depending on the issue. Go to
+    /// ``ATAPIError`` and ``ATRequestPrepareError`` for more details.
+    public func unassignModeratorFromReport(
+        _ reportID: Int
+    ) async throws -> ToolsOzoneLexicon.Report.ReportAssignmentViewDefinition {
+        guard let session = try await self.getUserSession() else {
+            throw ATRequestPrepareError.missingActiveSession
+        }
+
+        guard let sessionURL = session.pdsURL,
+              let requestURL = URL(string: "\(sessionURL)/xrpc/tools.ozone.report.unassignModerator") else {
+            throw ATRequestPrepareError.invalidRequestURL
+        }
+
+        let requestBody = ToolsOzoneLexicon.Report.UnassignModeratorRequestBody(reportID: reportID)
+
+        do {
+            let request = apiClientService.createRequest(
+                forRequest: requestURL,
+                andMethod: .post,
+                acceptValue: "application/json",
+                contentTypeValue: "application/json",
+                requiresAuthorization: true
+            )
+            let response = try await apiClientService.sendRequest(
+                request,
+                withEncodingBody: requestBody,
+                decodeTo: ToolsOzoneLexicon.Report.ReportAssignmentViewDefinition.self
+            )
+
+            return response
+        } catch {
+            throw error
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueAssignModerator.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueAssignModerator.swift
@@ -1,0 +1,59 @@
+//
+//  ToolsOzoneQueueAssignModerator.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Queue {
+
+    /// A request body model for assigning a moderator to a queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Assign a user to a queue."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.assignModerator`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/assignModerator.json
+    public struct AssignModeratorRequestBody: Sendable, Codable {
+
+        /// The ID of the queue to assign the user to.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The ID of the queue to assign
+        /// the user to."
+        public let queueID: Int
+
+        /// The decentralized identifier (DID) of the moderator to assign.
+        ///
+        /// - Note: According to the AT Protocol specifications: "DID to be assigned."
+        public let did: String
+
+        public init(queueID: Int, did: String) {
+            self.queueID = queueID
+            self.did = did
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.queueID = try container.decode(Int.self, forKey: .queueID)
+            self.did = try container.decode(String.self, forKey: .did)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.queueID, forKey: .queueID)
+            try container.encode(self.did, forKey: .did)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case queueID = "queueId"
+            case did
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueCreateQueue.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueCreateQueue.swift
@@ -1,0 +1,118 @@
+//
+//  ToolsOzoneQueueCreateQueue.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Queue {
+
+    /// A request body model for creating a new moderation queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Create a new moderation queue. A queue
+    /// can have optional matching criteria that ozone's queue router will use to match reports. A
+    /// queue with no criteria must have reports assigned to it manually via (1) `modTool.meta.queueId`
+    /// in `tools.ozone.moderation.emitEvent` or (2) `tools.ozone.report.reassignQueue`."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.createQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/createQueue.json
+    public struct CreateQueueRequestBody: Sendable, Codable {
+
+        /// The display name for the queue.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Display name for the queue
+        /// (must be unique)"
+        public let name: String
+
+        /// Subject types this queue accepts. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Subject types this queue accepts"
+        public let subjectTypes: [String]?
+
+        /// Collection name for record subjects. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Collection name for record subjects.
+        /// Required if subjectTypes includes 'record'."
+        public let collection: String?
+
+        /// Report reason types for this queue. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Report reason types
+        /// (fully qualified NSIDs)"
+        public let reportTypes: [String]?
+
+        /// A description of the queue. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional description of the queue"
+        public let description: String?
+
+        /// Recommended policy keys for actioning reports in this queue. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Policy keys to recommend when
+        /// actioning reports in this queue"
+        public let recommendedPolicies: [String]?
+
+        public init(name: String, subjectTypes: [String]? = nil, collection: String? = nil,
+                    reportTypes: [String]? = nil, description: String? = nil,
+                    recommendedPolicies: [String]? = nil) {
+            self.name = name
+            self.subjectTypes = subjectTypes
+            self.collection = collection
+            self.reportTypes = reportTypes
+            self.description = description
+            self.recommendedPolicies = recommendedPolicies
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.name = try container.decode(String.self, forKey: .name)
+            self.subjectTypes = try container.decodeIfPresent([String].self, forKey: .subjectTypes)
+            self.collection = try container.decodeIfPresent(String.self, forKey: .collection)
+            self.reportTypes = try container.decodeIfPresent([String].self, forKey: .reportTypes)
+            self.description = try container.decodeIfPresent(String.self, forKey: .description)
+            self.recommendedPolicies = try container.decodeIfPresent([String].self, forKey: .recommendedPolicies)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.name, forKey: .name)
+            try container.encodeIfPresent(self.subjectTypes, forKey: .subjectTypes)
+            try container.encodeIfPresent(self.collection, forKey: .collection)
+            if let reportTypes, reportTypes.count > 0 {
+                try container.truncatedEncode(reportTypes, forKey: .reportTypes, upToArrayLength: 25)
+            }
+            try container.encodeIfPresent(self.description, forKey: .description)
+            try container.encodeIfPresent(self.recommendedPolicies, forKey: .recommendedPolicies)
+        }
+
+        enum CodingKeys: CodingKey {
+            case name
+            case subjectTypes
+            case collection
+            case reportTypes
+            case description
+            case recommendedPolicies
+        }
+    }
+
+    /// An output model for creating a new moderation queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Create a new moderation queue."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.createQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/createQueue.json
+    public struct CreateQueueOutput: Sendable, Codable {
+
+        /// The newly created queue.
+        public let queue: QueueViewDefinition
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueDefs.swift
@@ -1,0 +1,325 @@
+//
+//  ToolsOzoneQueueDefs.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Queue {
+
+    /// A definition model for a moderation queue view.
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/defs.json
+    public struct QueueViewDefinition: Sendable, Codable {
+
+        /// The ID of the queue.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Queue ID"
+        public let id: Int
+
+        /// The display name of the queue.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Display name of the queue"
+        public let name: String
+
+        /// The subject types this queue accepts. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Subject types this queue accepts."
+        public let subjectTypes: [String]?
+
+        /// The collection name for record subjects. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Collection name for record subjects
+        /// (e.g., 'app.bsky.feed.post')"
+        public let collection: String?
+
+        /// Report reason types this queue accepts. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Report reason types this queue
+        /// accepts (fully qualified NSIDs)"
+        public let reportTypes: [String]?
+
+        /// A description of the queue. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional description of the queue"
+        public let description: String?
+
+        /// Recommended policy keys for actioning reports in this queue. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Policy keys recommended when
+        /// actioning reports in this queue"
+        public let recommendedPolicies: [String]?
+
+        /// The decentralized identifier (DID) of the moderator who created this queue.
+        ///
+        /// - Note: According to the AT Protocol specifications: "DID of moderator who created
+        /// this queue"
+        public let createdBy: String
+
+        /// The date and time the queue was created.
+        public let createdAt: Date
+
+        /// The date and time the queue was last updated.
+        public let updatedAt: Date
+
+        /// Whether this queue is currently active.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Whether this queue is currently active"
+        public let isEnabled: Bool
+
+        /// The date and time the queue was deleted, if applicable. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "When the queue was deleted,
+        /// if applicable"
+        public let deletedAt: Date?
+
+        /// Statistics about this queue.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Statistics about this queue"
+        public let stats: QueueStatisticsDefinition
+
+        public init(id: Int, name: String, subjectTypes: [String]? = nil, collection: String? = nil,
+                    reportTypes: [String]? = nil, description: String? = nil,
+                    recommendedPolicies: [String]? = nil, createdBy: String, createdAt: Date,
+                    updatedAt: Date, isEnabled: Bool, deletedAt: Date? = nil,
+                    stats: QueueStatisticsDefinition) {
+            self.id = id
+            self.name = name
+            self.subjectTypes = subjectTypes
+            self.collection = collection
+            self.reportTypes = reportTypes
+            self.description = description
+            self.recommendedPolicies = recommendedPolicies
+            self.createdBy = createdBy
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+            self.isEnabled = isEnabled
+            self.deletedAt = deletedAt
+            self.stats = stats
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.id = try container.decode(Int.self, forKey: .id)
+            self.name = try container.decode(String.self, forKey: .name)
+            self.subjectTypes = try container.decodeIfPresent([String].self, forKey: .subjectTypes)
+            self.collection = try container.decodeIfPresent(String.self, forKey: .collection)
+            self.reportTypes = try container.decodeIfPresent([String].self, forKey: .reportTypes)
+            self.description = try container.decodeIfPresent(String.self, forKey: .description)
+            self.recommendedPolicies = try container.decodeIfPresent([String].self, forKey: .recommendedPolicies)
+            self.createdBy = try container.decode(String.self, forKey: .createdBy)
+            self.createdAt = try container.decodeDate(forKey: .createdAt)
+            self.updatedAt = try container.decodeDate(forKey: .updatedAt)
+            self.isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
+            self.deletedAt = try container.decodeDateIfPresent(forKey: .deletedAt)
+            self.stats = try container.decode(QueueStatisticsDefinition.self, forKey: .stats)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.id, forKey: .id)
+            try container.encode(self.name, forKey: .name)
+            try container.encodeIfPresent(self.subjectTypes, forKey: .subjectTypes)
+            try container.encodeIfPresent(self.collection, forKey: .collection)
+            try container.encodeIfPresent(self.reportTypes, forKey: .reportTypes)
+            try container.encodeIfPresent(self.description, forKey: .description)
+            try container.encodeIfPresent(self.recommendedPolicies, forKey: .recommendedPolicies)
+            try container.encode(self.createdBy, forKey: .createdBy)
+            try container.encodeDate(self.createdAt, forKey: .createdAt)
+            try container.encodeDate(self.updatedAt, forKey: .updatedAt)
+            try container.encode(self.isEnabled, forKey: .isEnabled)
+            try container.encodeDateIfPresent(self.deletedAt, forKey: .deletedAt)
+            try container.encode(self.stats, forKey: .stats)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case name
+            case subjectTypes
+            case collection
+            case reportTypes
+            case description
+            case recommendedPolicies
+            case createdBy
+            case createdAt
+            case updatedAt
+            case isEnabled = "enabled"
+            case deletedAt
+            case stats
+        }
+    }
+
+    /// A definition model for queue statistics.
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/defs.json
+    public struct QueueStatisticsDefinition: Sendable, Codable {
+
+        /// The number of reports in 'open' status. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of reports in 'open' status"
+        public let pendingCount: Int?
+
+        /// The number of reports in 'closed' status. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of reports in 'closed' status"
+        public let actionedCount: Int?
+
+        /// The number of reports in 'escalated' status. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of reports in 'escalated' status"
+        public let escalatedCount: Int?
+
+        /// Reports received in this queue in the last 24 hours. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Reports received in this queue
+        /// in the last 24 hours."
+        public let inboundCount: Int?
+
+        /// Percentage of reports actioned, rounded to nearest integer. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Percentage of reports actioned
+        /// (actionedCount / inboundCount * 100), rounded to nearest integer. Absent when
+        /// inboundCount is 0."
+        public let actionRate: Int?
+
+        /// Average handling time in seconds. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Average time in seconds from report
+        /// creation to close, for reports closed in this period."
+        public let avgHandlingTimeSec: Int?
+
+        /// When these statistics were last computed. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "When these statistics were
+        /// last computed"
+        public let lastUpdated: Date?
+
+        public init(pendingCount: Int? = nil, actionedCount: Int? = nil,
+                    escalatedCount: Int? = nil, inboundCount: Int? = nil,
+                    actionRate: Int? = nil, avgHandlingTimeSec: Int? = nil,
+                    lastUpdated: Date? = nil) {
+            self.pendingCount = pendingCount
+            self.actionedCount = actionedCount
+            self.escalatedCount = escalatedCount
+            self.inboundCount = inboundCount
+            self.actionRate = actionRate
+            self.avgHandlingTimeSec = avgHandlingTimeSec
+            self.lastUpdated = lastUpdated
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.pendingCount = try container.decodeIfPresent(Int.self, forKey: .pendingCount)
+            self.actionedCount = try container.decodeIfPresent(Int.self, forKey: .actionedCount)
+            self.escalatedCount = try container.decodeIfPresent(Int.self, forKey: .escalatedCount)
+            self.inboundCount = try container.decodeIfPresent(Int.self, forKey: .inboundCount)
+            self.actionRate = try container.decodeIfPresent(Int.self, forKey: .actionRate)
+            self.avgHandlingTimeSec = try container.decodeIfPresent(Int.self, forKey: .avgHandlingTimeSec)
+            self.lastUpdated = try container.decodeDateIfPresent(forKey: .lastUpdated)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encodeIfPresent(self.pendingCount, forKey: .pendingCount)
+            try container.encodeIfPresent(self.actionedCount, forKey: .actionedCount)
+            try container.encodeIfPresent(self.escalatedCount, forKey: .escalatedCount)
+            try container.encodeIfPresent(self.inboundCount, forKey: .inboundCount)
+            try container.encodeIfPresent(self.actionRate, forKey: .actionRate)
+            try container.encodeIfPresent(self.avgHandlingTimeSec, forKey: .avgHandlingTimeSec)
+            try container.encodeDateIfPresent(self.lastUpdated, forKey: .lastUpdated)
+        }
+
+        enum CodingKeys: CodingKey {
+            case pendingCount
+            case actionedCount
+            case escalatedCount
+            case inboundCount
+            case actionRate
+            case avgHandlingTimeSec
+            case lastUpdated
+        }
+    }
+
+    /// A definition model for a queue moderator assignment view.
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/defs.json
+    public struct QueueAssignmentViewDefinition: Sendable, Codable {
+
+        /// The ID of the assignment.
+        public let id: Int
+
+        /// The decentralized identifier (DID) of the assigned moderator.
+        public let did: String
+
+        /// The full member record of the assigned moderator. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The moderator assigned to
+        /// this queue"
+        public let moderator: ToolsOzoneLexicon.Team.MemberDefinition?
+
+        /// The queue this assignment belongs to.
+        public let queue: QueueViewDefinition
+
+        /// The date and time the assignment starts.
+        public let startAt: Date
+
+        /// The date and time the assignment ends. Optional.
+        public let endAt: Date?
+
+        public init(id: Int, did: String, moderator: ToolsOzoneLexicon.Team.MemberDefinition? = nil,
+                    queue: QueueViewDefinition, startAt: Date, endAt: Date? = nil) {
+            self.id = id
+            self.did = did
+            self.moderator = moderator
+            self.queue = queue
+            self.startAt = startAt
+            self.endAt = endAt
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.id = try container.decode(Int.self, forKey: .id)
+            self.did = try container.decode(String.self, forKey: .did)
+            self.moderator = try container.decodeIfPresent(ToolsOzoneLexicon.Team.MemberDefinition.self, forKey: .moderator)
+            self.queue = try container.decode(QueueViewDefinition.self, forKey: .queue)
+            self.startAt = try container.decodeDate(forKey: .startAt)
+            self.endAt = try container.decodeDateIfPresent(forKey: .endAt)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.id, forKey: .id)
+            try container.encode(self.did, forKey: .did)
+            try container.encodeIfPresent(self.moderator, forKey: .moderator)
+            try container.encode(self.queue, forKey: .queue)
+            try container.encodeDate(self.startAt, forKey: .startAt)
+            try container.encodeDateIfPresent(self.endAt, forKey: .endAt)
+        }
+
+        enum CodingKeys: CodingKey {
+            case id
+            case did
+            case moderator
+            case queue
+            case startAt
+            case endAt
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueDeleteQueue.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueDeleteQueue.swift
@@ -1,0 +1,84 @@
+//
+//  ToolsOzoneQueueDeleteQueue.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Queue {
+
+    /// A request body model for deleting a moderation queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Delete a moderation queue.
+    /// Optionally migrate reports to another queue."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.deleteQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/deleteQueue.json
+    public struct DeleteQueueRequestBody: Sendable, Codable {
+
+        /// The ID of the queue to delete.
+        ///
+        /// - Note: According to the AT Protocol specifications: "ID of the queue to delete"
+        public let queueID: Int
+
+        /// The ID of the queue to migrate reports to. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional: migrate all reports to
+        /// this queue. If not specified, reports will be set to unassigned (-1)."
+        public let migrateToQueueID: Int?
+
+        public init(queueID: Int, migrateToQueueID: Int? = nil) {
+            self.queueID = queueID
+            self.migrateToQueueID = migrateToQueueID
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.queueID = try container.decode(Int.self, forKey: .queueID)
+            self.migrateToQueueID = try container.decodeIfPresent(Int.self, forKey: .migrateToQueueID)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.queueID, forKey: .queueID)
+            try container.encodeIfPresent(self.migrateToQueueID, forKey: .migrateToQueueID)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case queueID = "queueId"
+            case migrateToQueueID = "migrateToQueueId"
+        }
+    }
+
+    /// An output model for deleting a moderation queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Delete a moderation queue."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.deleteQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/deleteQueue.json
+    public struct DeleteQueueOutput: Sendable, Codable {
+
+        /// Whether the queue was deleted.
+        public let isDeleted: Bool
+
+        /// The number of reports migrated. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of reports that were
+        /// migrated (if migration occurred)"
+        public let reportsMigrated: Int?
+
+        enum CodingKeys: String, CodingKey {
+            case isDeleted = "deleted"
+            case reportsMigrated
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueGetAssignments.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueGetAssignments.swift
@@ -1,0 +1,31 @@
+//
+//  ToolsOzoneQueueGetAssignments.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Queue {
+
+    /// An output model for getting moderator assignments for queues.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get moderator assignments, optionally
+    /// filtered by active status, queue, or moderator."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.getAssignments`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/getAssignments.json
+    public struct GetAssignmentsOutput: Sendable, Codable {
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+
+        /// An array of queue moderator assignments.
+        public let assignments: [QueueAssignmentViewDefinition]
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueListQueues.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueListQueues.swift
@@ -1,0 +1,31 @@
+//
+//  ToolsOzoneQueueListQueues.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Queue {
+
+    /// An output model for listing all configured moderation queues.
+    ///
+    /// - Note: According to the AT Protocol specifications: "List all configured moderation
+    /// queues with statistics."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.listQueues`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/listQueues.json
+    public struct ListQueuesOutput: Sendable, Codable {
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+
+        /// An array of moderation queues.
+        public let queues: [QueueViewDefinition]
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueRouteReports.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueRouteReports.swift
@@ -1,0 +1,83 @@
+//
+//  ToolsOzoneQueueRouteReports.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Queue {
+
+    /// A request body model for routing reports to matching queues.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Route reports within an ID range to
+    /// matching queues based."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.routeReports`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/routeReports.json
+    public struct RouteReportsRequestBody: Sendable, Codable {
+
+        /// The start of the report ID range (inclusive).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Start of report ID range (inclusive)."
+        public let startReportID: Int
+
+        /// The end of the report ID range (inclusive).
+        ///
+        /// - Note: According to the AT Protocol specifications: "End of report ID range (inclusive).
+        /// Difference between start and end must be less than 5,000."
+        public let endReportID: Int
+
+        public init(startReportID: Int, endReportID: Int) {
+            self.startReportID = startReportID
+            self.endReportID = endReportID
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.startReportID = try container.decode(Int.self, forKey: .startReportID)
+            self.endReportID = try container.decode(Int.self, forKey: .endReportID)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.startReportID, forKey: .startReportID)
+            try container.encode(self.endReportID, forKey: .endReportID)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case startReportID = "startReportId"
+            case endReportID = "endReportId"
+        }
+    }
+
+    /// An output model for routing reports to matching queues.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Route reports within an ID range to
+    /// matching queues based."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.routeReports`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/routeReports.json
+    public struct RouteReportsOutput: Sendable, Codable {
+
+        /// The number of reports assigned to a queue.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The number of reports assigned
+        /// to a queue."
+        public let assigned: Int
+
+        /// The number of reports with no matching queue.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The number of reports with no
+        /// matching queue."
+        public let unmatched: Int
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueUnassignModerator.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueUnassignModerator.swift
@@ -1,0 +1,60 @@
+//
+//  ToolsOzoneQueueUnassignModerator.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Queue {
+
+    /// A request body model for removing a moderator's assignment from a queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Remove a user's assignment
+    /// from a queue."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.unassignModerator`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/unassignModerator.json
+    public struct UnassignModeratorRequestBody: Sendable, Codable {
+
+        /// The ID of the queue to unassign the user from.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The ID of the queue to unassign
+        /// the user from."
+        public let queueID: Int
+
+        /// The decentralized identifier (DID) of the moderator to unassign.
+        ///
+        /// - Note: According to the AT Protocol specifications: "DID to be unassigned."
+        public let did: String
+
+        public init(queueID: Int, did: String) {
+            self.queueID = queueID
+            self.did = did
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.queueID = try container.decode(Int.self, forKey: .queueID)
+            self.did = try container.decode(String.self, forKey: .did)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.queueID, forKey: .queueID)
+            try container.encode(self.did, forKey: .did)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case queueID = "queueId"
+            case did
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueUpdateQueue.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueUpdateQueue.swift
@@ -1,0 +1,100 @@
+//
+//  ToolsOzoneQueueUpdateQueue.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Queue {
+
+    /// A request body model for updating queue properties.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Update queue properties."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.updateQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/updateQueue.json
+    public struct UpdateQueueRequestBody: Sendable, Codable {
+
+        /// The ID of the queue to update.
+        ///
+        /// - Note: According to the AT Protocol specifications: "ID of the queue to update"
+        public let queueID: Int
+
+        /// A new display name for the queue. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "New display name for the queue"
+        public let name: String?
+
+        /// Whether the queue is enabled. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Enable or disable the queue"
+        public let isEnabled: Bool?
+
+        /// A description of the queue. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional description of the queue"
+        public let description: String?
+
+        /// Recommended policy keys for actioning reports in this queue. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Policy keys to recommend when
+        /// actioning reports in this queue"
+        public let recommendedPolicies: [String]?
+
+        public init(queueID: Int, name: String? = nil, isEnabled: Bool? = nil,
+                    description: String? = nil, recommendedPolicies: [String]? = nil) {
+            self.queueID = queueID
+            self.name = name
+            self.isEnabled = isEnabled
+            self.description = description
+            self.recommendedPolicies = recommendedPolicies
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.queueID = try container.decode(Int.self, forKey: .queueID)
+            self.name = try container.decodeIfPresent(String.self, forKey: .name)
+            self.isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled)
+            self.description = try container.decodeIfPresent(String.self, forKey: .description)
+            self.recommendedPolicies = try container.decodeIfPresent([String].self, forKey: .recommendedPolicies)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.queueID, forKey: .queueID)
+            try container.encodeIfPresent(self.name, forKey: .name)
+            try container.encodeIfPresent(self.isEnabled, forKey: .isEnabled)
+            try container.encodeIfPresent(self.description, forKey: .description)
+            try container.encodeIfPresent(self.recommendedPolicies, forKey: .recommendedPolicies)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case queueID = "queueId"
+            case name
+            case isEnabled = "enabled"
+            case description
+            case recommendedPolicies
+        }
+    }
+
+    /// An output model for updating queue properties.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Update queue properties."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.queue.updateQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/queue/updateQueue.json
+    public struct UpdateQueueOutput: Sendable, Codable {
+
+        /// The updated queue.
+        public let queue: QueueViewDefinition
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportAssignModerator.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportAssignModerator.swift
@@ -1,0 +1,83 @@
+//
+//  ToolsOzoneReportAssignModerator.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// A request body model for assigning a moderator to a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Assign a report to a user. Defaults
+    /// to the caller. Admins may assign to any moderator."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.assignModerator`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/assignModerator.json
+    public struct AssignModeratorRequestBody: Sendable, Codable {
+
+        /// The ID of the report to assign.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The ID of the report to assign."
+        public let reportID: Int
+
+        /// An optional queue ID to associate the assignment with. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional queue ID to associate the
+        /// assignment with. If not provided and the report has been assigned on a queue before,
+        /// it will stay on that queue."
+        public let queueID: Int?
+
+        /// The decentralized identifier (DID) of the moderator to assign. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "DID to be assigned. Defaults to
+        /// the caller's DID. Admins may assign to any moderator."
+        public let did: String?
+
+        /// Whether the assignment has no expiry. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "When true, the assignment has no
+        /// expiry (endAt is null). Throws AlreadyAssigned if another user already has a permanent
+        /// assignment on this report."
+        public let isPermanent: Bool?
+
+        public init(reportID: Int, queueID: Int? = nil, did: String? = nil,
+                    isPermanent: Bool? = nil) {
+            self.reportID = reportID
+            self.queueID = queueID
+            self.did = did
+            self.isPermanent = isPermanent
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.reportID = try container.decode(Int.self, forKey: .reportID)
+            self.queueID = try container.decodeIfPresent(Int.self, forKey: .queueID)
+            self.did = try container.decodeIfPresent(String.self, forKey: .did)
+            self.isPermanent = try container.decodeIfPresent(Bool.self, forKey: .isPermanent)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.reportID, forKey: .reportID)
+            try container.encodeIfPresent(self.queueID, forKey: .queueID)
+            try container.encodeIfPresent(self.did, forKey: .did)
+            try container.encodeIfPresent(self.isPermanent, forKey: .isPermanent)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case reportID = "reportId"
+            case queueID = "queueId"
+            case did
+            case isPermanent
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportCloseReports.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportCloseReports.swift
@@ -1,0 +1,114 @@
+//
+//  ToolsOzoneReportCloseReports.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// A request body model for closing all reports on a subject matching the given criteria.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Close all reports on a subject
+    /// matching the given criteria. Reports whose current status does not permit a transition
+    /// to closed are skipped silently. Intended for automated flows that resolve reports
+    /// without taking action on the subject."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.closeReports`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/closeReports.json
+    public struct CloseReportsRequestBody: Sendable, Codable {
+
+        /// The subject whose reports should be closed.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Subject DID (account-level
+        /// reports) or AT-URI (record-level reports) whose reports should be closed."
+        public let subject: String
+
+        /// A filter of report types to close. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "If specified, only reports of
+        /// the given report types (fully qualified reason NSIDs) are closed. When omitted, all
+        /// non-closed reports on the subject are targeted."
+        public let reportTypes: [String]?
+
+        /// A moderator-only note recorded on each close activity. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional moderator-only note
+        /// recorded on each close activity. Not visible to reporters."
+        public let internalNote: String?
+
+        /// Determines whether this action is triggered by an automated process. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Set true when this action is
+        /// triggered by an automated process. Defaults to false."
+        public let isAutomated: Bool?
+
+        public init(subject: String, reportTypes: [String]? = nil, internalNote: String? = nil, isAutomated: Bool? = nil) {
+            self.subject = subject
+            self.reportTypes = reportTypes
+            self.internalNote = internalNote
+            self.isAutomated = isAutomated
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.subject = try container.decode(String.self, forKey: .subject)
+            self.reportTypes = try container.decodeIfPresent([String].self, forKey: .reportTypes)
+            self.internalNote = try container.decodeIfPresent(String.self, forKey: .internalNote)
+            self.isAutomated = try container.decodeIfPresent(Bool.self, forKey: .isAutomated)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.subject, forKey: .subject)
+            try container.encodeIfPresent(self.reportTypes, forKey: .reportTypes)
+            try container.encodeIfPresent(self.internalNote, forKey: .internalNote)
+            try container.encodeIfPresent(self.isAutomated, forKey: .isAutomated)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case subject
+            case reportTypes
+            case internalNote
+            case isAutomated
+        }
+    }
+
+    /// An output model for closing all reports on a subject matching the given criteria.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Close all reports on a subject
+    /// matching the given criteria. Reports whose current status does not permit a transition
+    /// to closed are skipped silently. Intended for automated flows that resolve reports
+    /// without taking action on the subject."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.closeReports`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/closeReports.json
+    public struct CloseReportsOutput: Sendable, Codable {
+
+        /// The number of reports that were transitioned to closed.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of reports that were
+        /// transitioned to closed."
+        public let closedCount: Int
+
+        /// The IDs of the reports that were closed.
+        ///
+        /// - Note: According to the AT Protocol specifications: "IDs of the reports that
+        /// were closed."
+        public let reportIDs: [Int]
+
+        enum CodingKeys: String, CodingKey {
+            case closedCount
+            case reportIDs = "reportIds"
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportCreateActivity.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportCreateActivity.swift
@@ -1,0 +1,116 @@
+//
+//  ToolsOzoneReportCreateActivity.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// A request body model for registering an activity on a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Register an activity on a report. For
+    /// state-change activity types, validates the transition and updates report.status atomically."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.createActivity`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/createActivity.json
+    public struct CreateActivityRequestBody: Sendable, Codable {
+
+        /// The ID of the report to record activity on. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "ID of the report to record activity
+        /// on. Exactly one of reportId or eventId must be provided."
+        public let reportID: Int?
+
+        /// The ID of the report moderation event. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "ID of the report moderation event.
+        /// Resolves to the report created from that event. Exactly one of reportId or eventId
+        /// must be provided."
+        public let eventID: Int?
+
+        /// The type of activity to record.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The type of activity to record."
+        public let activity: ActivityUnion
+
+        /// An optional moderator-only note. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional moderator-only note.
+        /// Not visible to reporters."
+        public let internalNote: String?
+
+        /// An optional public-facing note. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional public-facing note,
+        /// potentially visible to the reporter."
+        public let publicNote: String?
+
+        /// Whether this activity is triggered by an automated process. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Set true when this activity is
+        /// triggered by an automated process. Defaults to false."
+        public let isAutomated: Bool?
+
+        public init(reportID: Int? = nil, eventID: Int? = nil, activity: ActivityUnion,
+                    internalNote: String? = nil, publicNote: String? = nil,
+                    isAutomated: Bool? = nil) {
+            self.reportID = reportID
+            self.eventID = eventID
+            self.activity = activity
+            self.internalNote = internalNote
+            self.publicNote = publicNote
+            self.isAutomated = isAutomated
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.reportID = try container.decodeIfPresent(Int.self, forKey: .reportID)
+            self.eventID = try container.decodeIfPresent(Int.self, forKey: .eventID)
+            self.activity = try container.decode(ActivityUnion.self, forKey: .activity)
+            self.internalNote = try container.decodeIfPresent(String.self, forKey: .internalNote)
+            self.publicNote = try container.decodeIfPresent(String.self, forKey: .publicNote)
+            self.isAutomated = try container.decodeIfPresent(Bool.self, forKey: .isAutomated)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encodeIfPresent(self.reportID, forKey: .reportID)
+            try container.encodeIfPresent(self.eventID, forKey: .eventID)
+            try container.encode(self.activity, forKey: .activity)
+            try container.encodeIfPresent(self.internalNote, forKey: .internalNote)
+            try container.encodeIfPresent(self.publicNote, forKey: .publicNote)
+            try container.encodeIfPresent(self.isAutomated, forKey: .isAutomated)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case reportID = "reportId"
+            case eventID = "eventId"
+            case activity
+            case internalNote
+            case publicNote
+            case isAutomated
+        }
+    }
+
+    /// An output model for registering an activity on a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Register an activity on a report."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.createActivity`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/createActivity.json
+    public struct CreateActivityOutput: Sendable, Codable {
+
+        /// The recorded activity.
+        public let activity: ReportActivityViewDefinition
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportDefs.swift
@@ -1,0 +1,913 @@
+//
+//  ToolsOzoneReportDefs.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// The current status of a moderation report.
+    public enum ReportStatus: String, Sendable, Codable {
+
+        /// The report is open and awaiting action.
+        case open
+
+        /// The report has been closed.
+        case closed
+
+        /// The report has been escalated.
+        case escalated
+
+        /// The report has been placed into a queue.
+        case queued
+
+        /// The report has been assigned to a moderator.
+        case assigned
+    }
+
+    /// A definition model for a report moderator assignment.
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct ReportAssignmentDefinition: Sendable, Codable {
+
+        /// The decentralized identifier (DID) of the assigned moderator.
+        ///
+        /// - Note: According to the AT Protocol specifications: "DID of the assigned moderator"
+        public let did: String
+
+        /// The full member record of the assigned moderator. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Full member record of the
+        /// assigned moderator"
+        public let moderator: ToolsOzoneLexicon.Team.MemberDefinition?
+
+        /// The date and time the report was assigned.
+        ///
+        /// - Note: According to the AT Protocol specifications: "When the report was assigned"
+        public let assignedAt: Date
+
+        public init(did: String, moderator: ToolsOzoneLexicon.Team.MemberDefinition? = nil,
+                    assignedAt: Date) {
+            self.did = did
+            self.moderator = moderator
+            self.assignedAt = assignedAt
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.did = try container.decode(String.self, forKey: .did)
+            self.moderator = try container.decodeIfPresent(ToolsOzoneLexicon.Team.MemberDefinition.self, forKey: .moderator)
+            self.assignedAt = try container.decodeDate(forKey: .assignedAt)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.did, forKey: .did)
+            try container.encodeIfPresent(self.moderator, forKey: .moderator)
+            try container.encodeDate(self.assignedAt, forKey: .assignedAt)
+        }
+
+        enum CodingKeys: CodingKey {
+            case did
+            case moderator
+            case assignedAt
+        }
+    }
+
+    /// A definition model for a moderation report view.
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct ReportViewDefinition: Sendable, Codable {
+
+        /// The ID of the report.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Report ID"
+        public let id: Int
+
+        /// The ID of the moderation event that created this report.
+        ///
+        /// - Note: According to the AT Protocol specifications: "ID of the moderation event that
+        /// created this report"
+        public let eventID: Int
+
+        /// The current status of the report.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Current status of the report"
+        public let status: ReportStatus
+
+        /// The subject that was reported.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The subject that was reported
+        /// with full details"
+        public let subject: ToolsOzoneLexicon.Moderation.SubjectViewDefinition
+
+        /// The type of report.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Type of report"
+        public let reportType: ComAtprotoLexicon.Moderation.ReasonTypeDefinition
+
+        /// The decentralized identifier (DID) of the user who made the report.
+        ///
+        /// - Note: According to the AT Protocol specifications: "DID of the user who made
+        /// the report"
+        public let reportedBy: String
+
+        /// The subject view of the reporter account.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Full subject view of the
+        /// reporter account"
+        public let reporter: ToolsOzoneLexicon.Moderation.SubjectViewDefinition
+
+        /// A comment provided by the reporter. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Comment provided by the reporter"
+        public let comment: String?
+
+        /// The date and time the report was created.
+        ///
+        /// - Note: According to the AT Protocol specifications: "When the report was created"
+        public let createdAt: Date
+
+        /// The date and time the report was last updated. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "When the report was last updated"
+        public let updatedAt: Date?
+
+        /// The date and time the report was assigned to its current queue. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "When the report was assigned to
+        /// its current queue"
+        public let queuedAt: Date?
+
+        /// An array of moderation event IDs for actions taken on this report. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Array of moderation event IDs
+        /// representing actions taken on this report (sorted DESC, most recent first)"
+        public let actionEventIDs: [Int]?
+
+        /// Expanded action events. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional: expanded action events"
+        public let actions: [ToolsOzoneLexicon.Moderation.ModerationEventViewDefinition]?
+
+        /// A note sent to the reporter when the report was actioned. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Note sent to reporter when report
+        /// was actioned"
+        public let actionNote: String?
+
+        /// The current status of the reported subject. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Current status of the
+        /// reported subject"
+        public let subjectStatus: ToolsOzoneLexicon.Moderation.SubjectStatusViewDefinition?
+
+        /// The number of other pending reports on the same subject. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of other pending reports
+        /// on the same subject"
+        public let relatedReportCount: Int?
+
+        /// The moderator currently assigned to this report, if any. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Information about moderator
+        /// currently assigned to this report (if any)"
+        public let assignment: ReportAssignmentDefinition?
+
+        /// The queue this report is assigned to, if any. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The queue this report is
+        /// assigned to (if any)"
+        public let queue: ToolsOzoneLexicon.Queue.QueueViewDefinition?
+
+        /// Whether this report is muted. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Whether this report is muted.
+        /// A report is muted if the reporter was muted or the subject was muted at the time
+        /// the report was created."
+        public let isMuted: Bool?
+
+        /// Whether this report was emitted by automated tooling. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Whether this report was emitted
+        /// by automated tooling."
+        public let isAutomated: Bool?
+
+        public init(id: Int, eventID: Int, status: ReportStatus,
+                    subject: ToolsOzoneLexicon.Moderation.SubjectViewDefinition,
+                    reportType: ComAtprotoLexicon.Moderation.ReasonTypeDefinition,
+                    reportedBy: String,
+                    reporter: ToolsOzoneLexicon.Moderation.SubjectViewDefinition,
+                    comment: String? = nil, createdAt: Date, updatedAt: Date? = nil,
+                    queuedAt: Date? = nil, actionEventIDs: [Int]? = nil,
+                    actions: [ToolsOzoneLexicon.Moderation.ModerationEventViewDefinition]? = nil,
+                    actionNote: String? = nil,
+                    subjectStatus: ToolsOzoneLexicon.Moderation.SubjectStatusViewDefinition? = nil,
+                    relatedReportCount: Int? = nil, assignment: ReportAssignmentDefinition? = nil,
+                    queue: ToolsOzoneLexicon.Queue.QueueViewDefinition? = nil,
+                    isMuted: Bool? = nil, isAutomated: Bool? = nil) {
+            self.id = id
+            self.eventID = eventID
+            self.status = status
+            self.subject = subject
+            self.reportType = reportType
+            self.reportedBy = reportedBy
+            self.reporter = reporter
+            self.comment = comment
+            self.createdAt = createdAt
+            self.updatedAt = updatedAt
+            self.queuedAt = queuedAt
+            self.actionEventIDs = actionEventIDs
+            self.actions = actions
+            self.actionNote = actionNote
+            self.subjectStatus = subjectStatus
+            self.relatedReportCount = relatedReportCount
+            self.assignment = assignment
+            self.queue = queue
+            self.isMuted = isMuted
+            self.isAutomated = isAutomated
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.id = try container.decode(Int.self, forKey: .id)
+            self.eventID = try container.decode(Int.self, forKey: .eventID)
+            self.status = try container.decode(ReportStatus.self, forKey: .status)
+            self.subject = try container.decode(ToolsOzoneLexicon.Moderation.SubjectViewDefinition.self, forKey: .subject)
+            self.reportType = try container.decode(ComAtprotoLexicon.Moderation.ReasonTypeDefinition.self, forKey: .reportType)
+            self.reportedBy = try container.decode(String.self, forKey: .reportedBy)
+            self.reporter = try container.decode(ToolsOzoneLexicon.Moderation.SubjectViewDefinition.self, forKey: .reporter)
+            self.comment = try container.decodeIfPresent(String.self, forKey: .comment)
+            self.createdAt = try container.decodeDate(forKey: .createdAt)
+            self.updatedAt = try container.decodeDateIfPresent(forKey: .updatedAt)
+            self.queuedAt = try container.decodeDateIfPresent(forKey: .queuedAt)
+            self.actionEventIDs = try container.decodeIfPresent([Int].self, forKey: .actionEventIDs)
+            self.actions = try container.decodeIfPresent([ToolsOzoneLexicon.Moderation.ModerationEventViewDefinition].self, forKey: .actions)
+            self.actionNote = try container.decodeIfPresent(String.self, forKey: .actionNote)
+            self.subjectStatus = try container.decodeIfPresent(ToolsOzoneLexicon.Moderation.SubjectStatusViewDefinition.self, forKey: .subjectStatus)
+            self.relatedReportCount = try container.decodeIfPresent(Int.self, forKey: .relatedReportCount)
+            self.assignment = try container.decodeIfPresent(ReportAssignmentDefinition.self, forKey: .assignment)
+            self.queue = try container.decodeIfPresent(ToolsOzoneLexicon.Queue.QueueViewDefinition.self, forKey: .queue)
+            self.isMuted = try container.decodeIfPresent(Bool.self, forKey: .isMuted)
+            self.isAutomated = try container.decodeIfPresent(Bool.self, forKey: .isAutomated)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.id, forKey: .id)
+            try container.encode(self.eventID, forKey: .eventID)
+            try container.encode(self.status, forKey: .status)
+            try container.encode(self.subject, forKey: .subject)
+            try container.encode(self.reportType, forKey: .reportType)
+            try container.encode(self.reportedBy, forKey: .reportedBy)
+            try container.encode(self.reporter, forKey: .reporter)
+            try container.encodeIfPresent(self.comment, forKey: .comment)
+            try container.encodeDate(self.createdAt, forKey: .createdAt)
+            try container.encodeDateIfPresent(self.updatedAt, forKey: .updatedAt)
+            try container.encodeDateIfPresent(self.queuedAt, forKey: .queuedAt)
+            try container.encodeIfPresent(self.actionEventIDs, forKey: .actionEventIDs)
+            try container.encodeIfPresent(self.actions, forKey: .actions)
+            try container.encodeIfPresent(self.actionNote, forKey: .actionNote)
+            try container.encodeIfPresent(self.subjectStatus, forKey: .subjectStatus)
+            try container.encodeIfPresent(self.relatedReportCount, forKey: .relatedReportCount)
+            try container.encodeIfPresent(self.assignment, forKey: .assignment)
+            try container.encodeIfPresent(self.queue, forKey: .queue)
+            try container.encodeIfPresent(self.isMuted, forKey: .isMuted)
+            try container.encodeIfPresent(self.isAutomated, forKey: .isAutomated)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case eventID = "eventId"
+            case status
+            case subject
+            case reportType
+            case reportedBy
+            case reporter
+            case comment
+            case createdAt
+            case updatedAt
+            case queuedAt
+            case actionEventIDs = "actionEventIds"
+            case actions
+            case actionNote
+            case subjectStatus
+            case relatedReportCount
+            case assignment
+            case queue
+            case isMuted
+            case isAutomated
+        }
+    }
+
+    /// A definition model for a queue activity on a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Activity recording a report being
+    /// routed to a queue."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct QueueActivityDefinition: Sendable, Codable {
+
+        /// The report's status before this activity. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The report's status before this
+        /// activity. Populated automatically from the report row; not required in input."
+        public let previousStatus: ReportStatus?
+    }
+
+    /// A definition model for an assignment activity on a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Activity recording a moderator being
+    /// assigned to a report."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct AssignmentActivityDefinition: Sendable, Codable {
+
+        /// The report's status before this activity. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The report's status before this
+        /// activity. Populated automatically from the report row; not required in input."
+        public let previousStatus: ReportStatus?
+    }
+
+    /// A definition model for an escalation activity on a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Activity recording a report
+    /// being escalated."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct EscalationActivityDefinition: Sendable, Codable {
+
+        /// The report's status before this activity. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The report's status before this
+        /// activity. Populated automatically from the report row; not required in input."
+        public let previousStatus: ReportStatus?
+    }
+
+    /// A definition model for a close activity on a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Activity recording a report
+    /// being closed."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct CloseActivityDefinition: Sendable, Codable {
+
+        /// The report's status before this activity. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The report's status before this
+        /// activity. Populated automatically from the report row; not required in input."
+        public let previousStatus: ReportStatus?
+    }
+
+    /// A definition model for a reopen activity on a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Activity recording a closed report
+    /// being reopened. Only valid when the report is in 'closed' status."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct ReopenActivityDefinition: Sendable, Codable {
+
+        /// The report's status before this activity. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The report's status before this
+        /// activity. Populated automatically from the report row; not required in input."
+        public let previousStatus: ReportStatus?
+    }
+
+    /// A definition model for a note activity on a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Activity recording a note on a report.
+    /// Use internalNote for moderator-only notes or publicNote for reporter-visible notes
+    /// (or both)."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct NoteActivityDefinition: Sendable, Codable {}
+
+    /// A union of activity types for a moderation report.
+    public enum ActivityUnion: ATUnionProtocol {
+
+        /// A queue activity.
+        case queueActivity(QueueActivityDefinition)
+
+        /// An assignment activity.
+        case assignmentActivity(AssignmentActivityDefinition)
+
+        /// An escalation activity.
+        case escalationActivity(EscalationActivityDefinition)
+
+        /// A close activity.
+        case closeActivity(CloseActivityDefinition)
+
+        /// A reopen activity.
+        case reopenActivity(ReopenActivityDefinition)
+
+        /// A note activity.
+        case noteActivity(NoteActivityDefinition)
+
+        /// An unknown activity.
+        case unknown(String, [String: CodableValue])
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let type = try container.decodeIfPresent(String.self, forKey: .type)
+
+            switch type {
+                case "tools.ozone.report.defs#queueActivity":
+                    self = .queueActivity(try QueueActivityDefinition(from: decoder))
+                case "tools.ozone.report.defs#assignmentActivity":
+                    self = .assignmentActivity(try AssignmentActivityDefinition(from: decoder))
+                case "tools.ozone.report.defs#escalationActivity":
+                    self = .escalationActivity(try EscalationActivityDefinition(from: decoder))
+                case "tools.ozone.report.defs#closeActivity":
+                    self = .closeActivity(try CloseActivityDefinition(from: decoder))
+                case "tools.ozone.report.defs#reopenActivity":
+                    self = .reopenActivity(try ReopenActivityDefinition(from: decoder))
+                case "tools.ozone.report.defs#noteActivity":
+                    self = .noteActivity(try NoteActivityDefinition(from: decoder))
+                default:
+                    let singleValueDecodingContainer = try decoder.singleValueContainer()
+                    let dictionary = try Self.decodeDictionary(from: singleValueDecodingContainer, decoder: decoder)
+                    self = .unknown(type ?? "unknown", dictionary)
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            switch self {
+                case .queueActivity(let activity):
+                    try container.encode("tools.ozone.report.defs#queueActivity", forKey: .type)
+                    try activity.encode(to: encoder)
+                case .assignmentActivity(let activity):
+                    try container.encode("tools.ozone.report.defs#assignmentActivity", forKey: .type)
+                    try activity.encode(to: encoder)
+                case .escalationActivity(let activity):
+                    try container.encode("tools.ozone.report.defs#escalationActivity", forKey: .type)
+                    try activity.encode(to: encoder)
+                case .closeActivity(let activity):
+                    try container.encode("tools.ozone.report.defs#closeActivity", forKey: .type)
+                    try activity.encode(to: encoder)
+                case .reopenActivity(let activity):
+                    try container.encode("tools.ozone.report.defs#reopenActivity", forKey: .type)
+                    try activity.encode(to: encoder)
+                case .noteActivity(let activity):
+                    try container.encode("tools.ozone.report.defs#noteActivity", forKey: .type)
+                    try activity.encode(to: encoder)
+                case .unknown(let type, _):
+                    try container.encode(type, forKey: .type)
+            }
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case type = "$type"
+        }
+    }
+
+    /// A definition model for a single activity entry on a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "A single activity entry on a report."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct ReportActivityViewDefinition: Sendable, Codable {
+
+        /// The ID of the activity.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Activity ID"
+        public let id: Int
+
+        /// The ID of the report this activity belongs to.
+        ///
+        /// - Note: According to the AT Protocol specifications: "ID of the report this activity
+        /// belongs to"
+        public let reportID: Int
+
+        /// The typed activity object describing what occurred.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The typed activity object
+        /// describing what occurred."
+        public let activity: ActivityUnion
+
+        /// An optional moderator-only note. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional moderator-only note.
+        /// Not visible to reporters."
+        public let internalNote: String?
+
+        /// An optional public note, potentially visible to the reporter. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional public note, potentially
+        /// visible to the reporter."
+        public let publicNote: String?
+
+        /// Extensible JSON payload for loose activity-specific metadata. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Extensible JSON payload for loose
+        /// activity-specific metadata (e.g. assignmentId)."
+        public let meta: UnknownType?
+
+        /// Whether this activity was created by an automated process.
+        ///
+        /// - Note: According to the AT Protocol specifications: "True if this activity was created
+        /// by an automated process (e.g. queue router) rather than a direct human action."
+        public let isAutomated: Bool
+
+        /// The decentralized identifier (DID) of the actor who created this activity.
+        ///
+        /// - Note: According to the AT Protocol specifications: "DID of the actor who created this
+        /// activity, or the service DID for automated activities."
+        public let createdBy: String
+
+        /// The full member record of the moderator who created this activity. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Full member record of the
+        /// moderator who created this activity"
+        public let moderator: ToolsOzoneLexicon.Team.MemberDefinition?
+
+        /// The full view of the report this activity belongs to. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Full view of the report this
+        /// activity belongs to."
+        public let report: ReportViewDefinition?
+
+        /// The date and time this activity was created.
+        ///
+        /// - Note: According to the AT Protocol specifications: "When this activity was created"
+        public let createdAt: Date
+
+        public init(id: Int, reportID: Int, activity: ActivityUnion, internalNote: String? = nil,
+                    publicNote: String? = nil, meta: UnknownType? = nil, isAutomated: Bool,
+                    createdBy: String, moderator: ToolsOzoneLexicon.Team.MemberDefinition? = nil,
+                    report: ReportViewDefinition? = nil, createdAt: Date) {
+            self.id = id
+            self.reportID = reportID
+            self.activity = activity
+            self.internalNote = internalNote
+            self.publicNote = publicNote
+            self.meta = meta
+            self.isAutomated = isAutomated
+            self.createdBy = createdBy
+            self.moderator = moderator
+            self.report = report
+            self.createdAt = createdAt
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.id = try container.decode(Int.self, forKey: .id)
+            self.reportID = try container.decode(Int.self, forKey: .reportID)
+            self.activity = try container.decode(ActivityUnion.self, forKey: .activity)
+            self.internalNote = try container.decodeIfPresent(String.self, forKey: .internalNote)
+            self.publicNote = try container.decodeIfPresent(String.self, forKey: .publicNote)
+            self.meta = try container.decodeIfPresent(UnknownType.self, forKey: .meta)
+            self.isAutomated = try container.decode(Bool.self, forKey: .isAutomated)
+            self.createdBy = try container.decode(String.self, forKey: .createdBy)
+            self.moderator = try container.decodeIfPresent(ToolsOzoneLexicon.Team.MemberDefinition.self, forKey: .moderator)
+            self.report = try container.decodeIfPresent(ReportViewDefinition.self, forKey: .report)
+            self.createdAt = try container.decodeDate(forKey: .createdAt)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.id, forKey: .id)
+            try container.encode(self.reportID, forKey: .reportID)
+            try container.encode(self.activity, forKey: .activity)
+            try container.encodeIfPresent(self.internalNote, forKey: .internalNote)
+            try container.encodeIfPresent(self.publicNote, forKey: .publicNote)
+            try container.encodeIfPresent(self.meta, forKey: .meta)
+            try container.encode(self.isAutomated, forKey: .isAutomated)
+            try container.encode(self.createdBy, forKey: .createdBy)
+            try container.encodeIfPresent(self.moderator, forKey: .moderator)
+            try container.encodeIfPresent(self.report, forKey: .report)
+            try container.encodeDate(self.createdAt, forKey: .createdAt)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case reportID = "reportId"
+            case activity
+            case internalNote
+            case publicNote
+            case meta
+            case isAutomated
+            case createdBy
+            case moderator
+            case report
+            case createdAt
+        }
+    }
+
+    /// A definition model for live report statistics.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Live statistics for reports for the
+    /// current calendar day, filterable by queue, moderator, or report type."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct LiveStatisticsDefinition: Sendable, Codable {
+
+        /// The number of reports currently not closed. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of reports currently
+        /// not closed."
+        public let pendingCount: Int?
+
+        /// The number of reports closed today. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of reports closed today."
+        public let actionedCount: Int?
+
+        /// The number of reports escalated today. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of reports escalated today."
+        public let escalatedCount: Int?
+
+        /// Reports received today. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Reports received today."
+        public let inboundCount: Int?
+
+        /// Percentage of reports actioned, rounded to nearest integer. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Percentage of reports actioned
+        /// (actionedCount / inboundCount * 100), rounded to nearest integer."
+        public let actionRate: Int?
+
+        /// Average handling time in seconds. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Average time in seconds from report
+        /// creation (or moderator assignment) to close."
+        public let avgHandlingTimeSec: Int?
+
+        /// When these statistics were last computed. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "When these statistics were
+        /// last computed."
+        public let lastUpdated: Date?
+
+        public init(pendingCount: Int? = nil, actionedCount: Int? = nil,
+                    escalatedCount: Int? = nil, inboundCount: Int? = nil,
+                    actionRate: Int? = nil, avgHandlingTimeSec: Int? = nil,
+                    lastUpdated: Date? = nil) {
+            self.pendingCount = pendingCount
+            self.actionedCount = actionedCount
+            self.escalatedCount = escalatedCount
+            self.inboundCount = inboundCount
+            self.actionRate = actionRate
+            self.avgHandlingTimeSec = avgHandlingTimeSec
+            self.lastUpdated = lastUpdated
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.pendingCount = try container.decodeIfPresent(Int.self, forKey: .pendingCount)
+            self.actionedCount = try container.decodeIfPresent(Int.self, forKey: .actionedCount)
+            self.escalatedCount = try container.decodeIfPresent(Int.self, forKey: .escalatedCount)
+            self.inboundCount = try container.decodeIfPresent(Int.self, forKey: .inboundCount)
+            self.actionRate = try container.decodeIfPresent(Int.self, forKey: .actionRate)
+            self.avgHandlingTimeSec = try container.decodeIfPresent(Int.self, forKey: .avgHandlingTimeSec)
+            self.lastUpdated = try container.decodeDateIfPresent(forKey: .lastUpdated)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encodeIfPresent(self.pendingCount, forKey: .pendingCount)
+            try container.encodeIfPresent(self.actionedCount, forKey: .actionedCount)
+            try container.encodeIfPresent(self.escalatedCount, forKey: .escalatedCount)
+            try container.encodeIfPresent(self.inboundCount, forKey: .inboundCount)
+            try container.encodeIfPresent(self.actionRate, forKey: .actionRate)
+            try container.encodeIfPresent(self.avgHandlingTimeSec, forKey: .avgHandlingTimeSec)
+            try container.encodeDateIfPresent(self.lastUpdated, forKey: .lastUpdated)
+        }
+
+        enum CodingKeys: CodingKey {
+            case pendingCount
+            case actionedCount
+            case escalatedCount
+            case inboundCount
+            case actionRate
+            case avgHandlingTimeSec
+            case lastUpdated
+        }
+    }
+
+    /// A definition model for a single daily snapshot of historical report statistics.
+    ///
+    /// - Note: According to the AT Protocol specifications: "A single daily snapshot of report
+    /// statistics for a calendar date."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct HistoricalStatisticsDefinition: Sendable, Codable {
+
+        /// The calendar date this snapshot covers (YYYY-MM-DD).
+        ///
+        /// - Note: According to the AT Protocol specifications: "The calendar date this snapshot
+        /// covers (YYYY-MM-DD)."
+        public let date: String
+
+        /// When this snapshot was last computed. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "When this snapshot was
+        /// last computed."
+        public let computedAt: Date?
+
+        /// The number of reports not closed at time of computation. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of reports not closed at
+        /// time of computation."
+        public let pendingCount: Int?
+
+        /// The number of reports closed during this day. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of reports closed during
+        /// this day."
+        public let actionedCount: Int?
+
+        /// The number of reports escalated during this day. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Number of reports escalated during
+        /// this day."
+        public let escalatedCount: Int?
+
+        /// Reports received during this day. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Reports received during this day."
+        public let inboundCount: Int?
+
+        /// Percentage of reports actioned, rounded to nearest integer. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Percentage of reports actioned
+        /// (actionedCount / inboundCount * 100), rounded to nearest integer."
+        public let actionRate: Int?
+
+        /// Average handling time in seconds. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Average time in seconds from report
+        /// creation (or moderator assignment) to close."
+        public let avgHandlingTimeSec: Int?
+
+        public init(date: String, computedAt: Date? = nil, pendingCount: Int? = nil,
+                    actionedCount: Int? = nil, escalatedCount: Int? = nil,
+                    inboundCount: Int? = nil, actionRate: Int? = nil,
+                    avgHandlingTimeSec: Int? = nil) {
+            self.date = date
+            self.computedAt = computedAt
+            self.pendingCount = pendingCount
+            self.actionedCount = actionedCount
+            self.escalatedCount = escalatedCount
+            self.inboundCount = inboundCount
+            self.actionRate = actionRate
+            self.avgHandlingTimeSec = avgHandlingTimeSec
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.date = try container.decode(String.self, forKey: .date)
+            self.computedAt = try container.decodeDateIfPresent(forKey: .computedAt)
+            self.pendingCount = try container.decodeIfPresent(Int.self, forKey: .pendingCount)
+            self.actionedCount = try container.decodeIfPresent(Int.self, forKey: .actionedCount)
+            self.escalatedCount = try container.decodeIfPresent(Int.self, forKey: .escalatedCount)
+            self.inboundCount = try container.decodeIfPresent(Int.self, forKey: .inboundCount)
+            self.actionRate = try container.decodeIfPresent(Int.self, forKey: .actionRate)
+            self.avgHandlingTimeSec = try container.decodeIfPresent(Int.self, forKey: .avgHandlingTimeSec)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.date, forKey: .date)
+            try container.encodeDateIfPresent(self.computedAt, forKey: .computedAt)
+            try container.encodeIfPresent(self.pendingCount, forKey: .pendingCount)
+            try container.encodeIfPresent(self.actionedCount, forKey: .actionedCount)
+            try container.encodeIfPresent(self.escalatedCount, forKey: .escalatedCount)
+            try container.encodeIfPresent(self.inboundCount, forKey: .inboundCount)
+            try container.encodeIfPresent(self.actionRate, forKey: .actionRate)
+            try container.encodeIfPresent(self.avgHandlingTimeSec, forKey: .avgHandlingTimeSec)
+        }
+
+        enum CodingKeys: CodingKey {
+            case date
+            case computedAt
+            case pendingCount
+            case actionedCount
+            case escalatedCount
+            case inboundCount
+            case actionRate
+            case avgHandlingTimeSec
+        }
+    }
+
+    /// A definition model for a report moderator assignment view.
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.defs`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/defs.json
+    public struct ReportAssignmentViewDefinition: Sendable, Codable {
+
+        /// The ID of the assignment.
+        public let id: Int
+
+        /// The decentralized identifier (DID) of the assigned moderator.
+        public let did: String
+
+        /// The full member record of the assigned moderator. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The moderator assigned to
+        /// this report"
+        public let moderator: ToolsOzoneLexicon.Team.MemberDefinition?
+
+        /// The queue this assignment is associated with. Optional.
+        public let queue: ToolsOzoneLexicon.Queue.QueueViewDefinition?
+
+        /// The ID of the report.
+        public let reportID: Int
+
+        /// The date and time the assignment starts.
+        public let startAt: Date
+
+        /// The date and time the assignment ends. Optional.
+        public let endAt: Date?
+
+        public init(id: Int, did: String, moderator: ToolsOzoneLexicon.Team.MemberDefinition? = nil,
+                    queue: ToolsOzoneLexicon.Queue.QueueViewDefinition? = nil,
+                    reportID: Int, startAt: Date, endAt: Date? = nil) {
+            self.id = id
+            self.did = did
+            self.moderator = moderator
+            self.queue = queue
+            self.reportID = reportID
+            self.startAt = startAt
+            self.endAt = endAt
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.id = try container.decode(Int.self, forKey: .id)
+            self.did = try container.decode(String.self, forKey: .did)
+            self.moderator = try container.decodeIfPresent(ToolsOzoneLexicon.Team.MemberDefinition.self, forKey: .moderator)
+            self.queue = try container.decodeIfPresent(ToolsOzoneLexicon.Queue.QueueViewDefinition.self, forKey: .queue)
+            self.reportID = try container.decode(Int.self, forKey: .reportID)
+            self.startAt = try container.decodeDate(forKey: .startAt)
+            self.endAt = try container.decodeDateIfPresent(forKey: .endAt)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.id, forKey: .id)
+            try container.encode(self.did, forKey: .did)
+            try container.encodeIfPresent(self.moderator, forKey: .moderator)
+            try container.encodeIfPresent(self.queue, forKey: .queue)
+            try container.encode(self.reportID, forKey: .reportID)
+            try container.encodeDate(self.startAt, forKey: .startAt)
+            try container.encodeDateIfPresent(self.endAt, forKey: .endAt)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case did
+            case moderator
+            case queue
+            case reportID = "reportId"
+            case startAt
+            case endAt
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetAssignments.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetAssignments.swift
@@ -1,0 +1,30 @@
+//
+//  ToolsOzoneReportGetAssignments.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// An output model for getting assignments for reports.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get assignments for reports."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.getAssignments`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/getAssignments.json
+    public struct GetAssignmentsOutput: Sendable, Codable {
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+
+        /// An array of report moderator assignments.
+        public let assignments: [ReportAssignmentViewDefinition]
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetHistoricalStats.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetHistoricalStats.swift
@@ -1,0 +1,32 @@
+//
+//  ToolsOzoneReportGetHistoricalStats.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// An output model for getting historical daily report statistics.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get historical daily report statistics.
+    /// Returns a paginated list of daily stat snapshots, newest first. Filter by queue, moderator,
+    /// or report type."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.getHistoricalStats`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/getHistoricalStats.json
+    public struct GetHistoricalStatsOutput: Sendable, Codable {
+
+        /// An array of daily historical statistics snapshots.
+        public let stats: [HistoricalStatisticsDefinition]
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetLatestReport.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetLatestReport.swift
@@ -1,0 +1,27 @@
+//
+//  ToolsOzoneReportGetLatestReport.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// An output model for getting the most recent moderation report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get the most recent report."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.getLatestReport`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/getLatestReport.json
+    public struct GetLatestReportOutput: Sendable, Codable {
+
+        /// The most recent moderation report.
+        public let report: ReportViewDefinition
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetLiveStats.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetLiveStats.swift
@@ -1,0 +1,32 @@
+//
+//  ToolsOzoneReportGetLiveStats.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// An output model for getting live report statistics.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Get live report statistics from the
+    /// past 24 hours. Filter by queue, moderator, or report type. Omit all parameters for
+    /// aggregate stats."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.getLiveStats`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/getLiveStats.json
+    public struct GetLiveStatsOutput: Sendable, Codable {
+
+        /// Statistics for the requested filter.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Statistics for the
+        /// requested filter."
+        public let stats: LiveStatisticsDefinition
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetReport.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetReport.swift
@@ -1,0 +1,14 @@
+//
+//  ToolsOzoneReportGetReport.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+// tools.ozone.report.getReport returns tools.ozone.report.defs#reportView directly.
+// No additional model is required beyond ReportViewDefinition in ToolsOzoneReportDefs.swift.

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportListActivities.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportListActivities.swift
@@ -1,0 +1,31 @@
+//
+//  ToolsOzoneReportListActivities.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// An output model for listing all activities for a report.
+    ///
+    /// - Note: According to the AT Protocol specifications: "List all activities for a report,
+    /// sorted most-recent-first."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.listActivities`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/listActivities.json
+    public struct ListActivitiesOutput: Sendable, Codable {
+
+        /// An array of report activities.
+        public let activities: [ReportActivityViewDefinition]
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportQueryActivities.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportQueryActivities.swift
@@ -1,0 +1,53 @@
+//
+//  ToolsOzoneReportQueryActivities.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// A definition model for querying report activities.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Query report activities across all
+    /// reports, ordered by createdAt. Used by downstream pollers; for per-report activity history
+    /// use listActivities."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.queryActivities`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/queryActivities.json
+    public struct QueryActivities: Sendable, Codable {
+
+        /// The sort direction for the results.
+        public enum SortDirection: String, Sendable, Codable {
+
+            /// Ascending order.
+            case ascending = "asc"
+
+            /// Descending order.
+            case descending = "desc"
+        }
+    }
+
+    /// An output model for querying report activities.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Query report activities across
+    /// all reports."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.queryActivities`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/queryActivities.json
+    public struct QueryActivitiesOutput: Sendable, Codable {
+
+        /// An array of report activities.
+        public let activities: [ReportActivityViewDefinition]
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportQueryReports.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportQueryReports.swift
@@ -1,0 +1,62 @@
+//
+//  ToolsOzoneReportQueryReports.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// A definition model for querying moderation reports.
+    ///
+    /// - Note: According to the AT Protocol specifications: "View moderation reports. Reports are
+    /// individual instances of content being reported, as opposed to subject statuses which
+    /// aggregate reports at the subject level."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.queryReports`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/queryReports.json
+    public struct QueryReports: Sendable, Codable {
+
+        /// The sort field for the results.
+        public enum SortField: String, Sendable, Codable {
+
+            /// Sort by creation date.
+            case createdAt
+
+            /// Sort by last update date.
+            case updatedAt
+        }
+
+        /// The sort direction for the results.
+        public enum SortDirection: String, Sendable, Codable {
+
+            /// Ascending order.
+            case ascending = "asc"
+
+            /// Descending order.
+            case descending = "desc"
+        }
+    }
+
+    /// An output model for querying moderation reports.
+    ///
+    /// - Note: According to the AT Protocol specifications: "View moderation reports."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.queryReports`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/queryReports.json
+    public struct QueryReportsOutput: Sendable, Codable {
+
+        /// The mark used to indicate the starting point for the next set of results. Optional.
+        public let cursor: String?
+
+        /// An array of moderation reports.
+        public let reports: [ReportViewDefinition]
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportReassignQueue.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportReassignQueue.swift
@@ -1,0 +1,84 @@
+//
+//  ToolsOzoneReportReassignQueue.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// A request body model for reassigning a report to a different queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Manually reassign a report to a
+    /// different queue (or unassign it). Records a queueActivity entry on the report."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.reassignQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/reassignQueue.json
+    public struct ReassignQueueRequestBody: Sendable, Codable {
+
+        /// The ID of the report to reassign.
+        ///
+        /// - Note: According to the AT Protocol specifications: "ID of the report to reassign"
+        public let reportID: Int
+
+        /// The target queue ID.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Target queue ID. Use -1 to
+        /// unassign from any queue."
+        public let queueID: Int
+
+        /// An optional moderator-only note. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional moderator-only note
+        /// recorded on the resulting queueActivity as internalNote."
+        public let comment: String?
+
+        public init(reportID: Int, queueID: Int, comment: String? = nil) {
+            self.reportID = reportID
+            self.queueID = queueID
+            self.comment = comment
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.reportID = try container.decode(Int.self, forKey: .reportID)
+            self.queueID = try container.decode(Int.self, forKey: .queueID)
+            self.comment = try container.decodeIfPresent(String.self, forKey: .comment)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.reportID, forKey: .reportID)
+            try container.encode(self.queueID, forKey: .queueID)
+            try container.encodeIfPresent(self.comment, forKey: .comment)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case reportID = "reportId"
+            case queueID = "queueId"
+            case comment
+        }
+    }
+
+    /// An output model for reassigning a report to a different queue.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Manually reassign a report to a
+    /// different queue."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.reassignQueue`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/reassignQueue.json
+    public struct ReassignQueueOutput: Sendable, Codable {
+
+        /// The updated report.
+        public let report: ReportViewDefinition
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportRefreshStats.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportRefreshStats.swift
@@ -1,0 +1,71 @@
+//
+//  ToolsOzoneReportRefreshStats.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// A request body model for recomputing report statistics.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Recompute report statistics for a
+    /// date range. Useful for backfilling after failures or data corrections."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.refreshStats`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/refreshStats.json
+    public struct RefreshStatsRequestBody: Sendable, Codable {
+
+        /// The start date for recomputation, inclusive (YYYY-MM-DD).
+        ///
+        /// - Note: According to the AT Protocol specifications: "Start date for recomputation,
+        /// inclusive (YYYY-MM-DD)."
+        public let startDate: String
+
+        /// The end date for recomputation, inclusive (YYYY-MM-DD).
+        ///
+        /// - Note: According to the AT Protocol specifications: "End date for recomputation,
+        /// inclusive (YYYY-MM-DD)."
+        public let endDate: String
+
+        /// An optional list of queue IDs to recompute. Optional.
+        ///
+        /// - Note: According to the AT Protocol specifications: "Optional list of queue IDs to
+        /// recompute. Omit to recompute all groups."
+        public let queueIDs: [Int]?
+
+        public init(startDate: String, endDate: String, queueIDs: [Int]? = nil) {
+            self.startDate = startDate
+            self.endDate = endDate
+            self.queueIDs = queueIDs
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.startDate = try container.decode(String.self, forKey: .startDate)
+            self.endDate = try container.decode(String.self, forKey: .endDate)
+            self.queueIDs = try container.decodeIfPresent([Int].self, forKey: .queueIDs)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.startDate, forKey: .startDate)
+            try container.encode(self.endDate, forKey: .endDate)
+            try container.encodeIfPresent(self.queueIDs, forKey: .queueIDs)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case startDate
+            case endDate
+            case queueIDs = "queueIds"
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportUnassignModerator.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportUnassignModerator.swift
@@ -1,0 +1,49 @@
+//
+//  ToolsOzoneReportUnassignModerator.swift
+//  ATProtoKit
+//
+//  Created by Keisuke Chinone on 2026-08-13.
+//
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+extension ToolsOzoneLexicon.Report {
+
+    /// A request body model for removing a report assignment.
+    ///
+    /// - Note: According to the AT Protocol specifications: "Remove report assignment."
+    ///
+    /// - SeeAlso: This is based on the [`tools.ozone.report.unassignModerator`][github] lexicon.
+    ///
+    /// [github]: https://github.com/bluesky-social/atproto/blob/main/lexicons/tools/ozone/report/unassignModerator.json
+    public struct UnassignModeratorRequestBody: Sendable, Codable {
+
+        /// The ID of the report to unassign.
+        ///
+        /// - Note: According to the AT Protocol specifications: "The ID of the report to unassign."
+        public let reportID: Int
+
+        public init(reportID: Int) {
+            self.reportID = reportID
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+
+            self.reportID = try container.decode(Int.self, forKey: .reportID)
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+
+            try container.encode(self.reportID, forKey: .reportID)
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case reportID = "reportId"
+        }
+    }
+}

--- a/Sources/ATProtoKit/Models/Lexicons/tools.ozone/ToolsOzoneLexicon.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/tools.ozone/ToolsOzoneLexicon.swift
@@ -16,6 +16,12 @@ extension ToolsOzoneLexicon {
     /// A group of lexicons within the `tools.ozone.moderation` namespace.
     public enum Moderation {}
 
+    /// A group of lexicons within the `tools.ozone.queue` namespace.
+    public enum Queue {}
+
+    /// A group of lexicons within the `tools.ozone.report` namespace.
+    public enum Report {}
+
     /// A group of lexicons within the `tools.ozone.safelink` namespace.
     public enum Safelink {}
 


### PR DESCRIPTION
## Description
Adds typed support for the full `tools.ozone.queue` and `tools.ozone.report` namespaces, covering queue lifecycle, moderator assignment, report routing, moderation activity, and stats.

### Added files

**Lexicon models — `tools.ozone.queue`:**
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueAssignModerator.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueCreateQueue.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueDefs.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueDeleteQueue.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueGetAssignments.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueListQueues.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueRouteReports.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueUnassignModerator.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Queue/ToolsOzoneQueueUpdateQueue.swift`

**Lexicon models — `tools.ozone.report`:**
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportAssignModerator.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportCloseReports.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportCreateActivity.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportDefs.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetAssignments.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetHistoricalStats.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetLatestReport.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetLiveStats.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportGetReport.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportListActivities.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportQueryActivities.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportQueryReports.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportReassignQueue.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportRefreshStats.swift`
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/Report/ToolsOzoneReportUnassignModerator.swift`

**API methods (`ATProtoAdmin`):**
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueAssignModeratorMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueCreateQueueMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueDeleteQueueMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueGetAssignmentsMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueListQueuesMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueRouteReportsMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueUnassignModeratorMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneQueueUpdateQueueMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportAssignModeratorMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportCloseReportsMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportCreateActivityMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetAssignmentsMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetHistoricalStatsMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetLatestReportMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetLiveStatsMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportGetReportMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportListActivitiesMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportQueryActivitiesMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportQueryReportsMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportReassignQueueMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportRefreshStatsMethod.swift`
- `Sources/ATProtoKit/APIReference/AdminAndModeratorAPI/ToolsOzoneReportUnassignModeratorMethod.swift`

**Modified:**
- `Sources/ATProtoKit/Models/Lexicons/tools.ozone/ToolsOzoneLexicon.swift` — registers the new `Queue` and `Report` namespaces

### New methods
`assignModeratorToQueue`, `createModerationQueue`, `deleteModerationQueue`, `getQueueAssignments`, `listModerationQueues`, `routeReportsToQueue`, `unassignModeratorFromQueue`, `updateModerationQueue`, `assignModeratorToReport`, `closeReports`, `createReportActivity`, `getReportAssignments`, `getHistoricalReportStats`, `getLatestReport`, `getLiveReportStats`, `getReport`, `listReportActivities`, `queryReportActivities`, `queryReports`, `reassignReportQueue`, `refreshReportStats`, `unassignModeratorFromReport`

This also covers `tools.ozone.report.closeReports`, which was added to the upstream lexicons after the issue was filed and is not listed in the issue's tables.

## Linked Issues
#324

## Type of Change
- [ ] Bug Fix
- [x] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
I know you mentioned you'd work through these yourself — hopefully this saves you the typing. This implementation serves as an interim typed layer for these two namespaces until ATLexiconC covers them. If this PR is useful before ATLexiconC lands, feel free to merge it; if ATLexiconC will supersede it, feel free to close without merging — no pressure either way.

Note: I don't have access to an Ozone moderator account, so I wasn't able to test these endpoints against a live service. The models and methods are written to match the lexicon definitions, and the package builds cleanly, but runtime behavior is unverified.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
