### PR TITLE
Add missing init in preferences and include new Describe Server property for blobUploadLimit

### DIFF
--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Actor/AppBskyActorDefs.swift
@@ -60,6 +60,21 @@ extension AppBskyLexicon.Actor {
         /// - Note: According to the AT Protocol specifications: "Debug information for internal development."
         public let debug: UnknownType?
 
+        public init(actorDID: String, actorHandle: String, displayName: String? = nil, pronouns: String? = nil, avatarImageURL: URL? = nil, associated: ProfileAssociatedDefinition? = nil, viewer: ViewerStateDefinition? = nil, labels: [ComAtprotoLexicon.Label.LabelDefinition]? = nil, createdAt: Date? = nil, verificationState: VerificationStateDefinition? = nil, status: StatusViewDefinition? = nil, debug: UnknownType? = nil) {
+            self.actorDID = actorDID
+            self.actorHandle = actorHandle
+            self.displayName = displayName
+            self.pronouns = pronouns
+            self.avatarImageURL = avatarImageURL
+            self.associated = associated
+            self.viewer = viewer
+            self.labels = labels
+            self.createdAt = createdAt
+            self.verificationState = verificationState
+            self.status = status
+            self.debug = debug
+        }
+
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
 
@@ -169,6 +184,23 @@ extension AppBskyLexicon.Actor {
         /// - Note: According to the AT Protocol specifications: "Debug information for internal development."
         public let debug: UnknownType?
 
+        public init(actorDID: String, actorHandle: String, displayName: String? = nil, description: String? = nil, pronouns: String? = nil, websiteURL: URL? = nil, avatarImageURL: URL? = nil, associated: ProfileAssociatedDefinition? = nil, indexedAt: Date? = nil, createdAt: Date? = nil, viewer: ViewerStateDefinition? = nil, labels: [ComAtprotoLexicon.Label.LabelDefinition]? = nil, verificationState: VerificationStateDefinition? = nil, status: StatusViewDefinition? = nil, debug: UnknownType? = nil) {
+            self.actorDID = actorDID
+            self.actorHandle = actorHandle
+            self.displayName = displayName
+            self.description = description
+            self.pronouns = pronouns
+            self.websiteURL = websiteURL
+            self.avatarImageURL = avatarImageURL
+            self.associated = associated
+            self.indexedAt = indexedAt
+            self.createdAt = createdAt
+            self.viewer = viewer
+            self.labels = labels
+            self.verificationState = verificationState
+            self.status = status
+            self.debug = nil
+        }
         public init(from decoder: any Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
 

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerDescribeServer.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Server/ComAtprotoServerDescribeServer.swift
@@ -95,6 +95,9 @@ extension ComAtprotoLexicon.Server {
         /// The decentralized identifier (DID) of the server.
         public let serverDID: String
 
+        /// Maximum size of a blob that can be uploaded via com.atproto.repo.uploadBlob, in bytes.
+        public let blobUploadLimit: Int?
+        
         enum CodingKeys: String, CodingKey {
             case isInviteCodeRequired = "inviteCodeRequired"
             case isPhoneVerificationRequired = "phoneVerificationRequired"
@@ -102,6 +105,7 @@ extension ComAtprotoLexicon.Server {
             case servicePolicyURLs = "links"
             case contactInformation = "contact"
             case serverDID = "did"
+            case blobUploadLimit
         }
     }
 }


### PR DESCRIPTION
## Description
Adds a missing initializer for the preferences struct; Adds the new "blobUploadLimit" to the Describe Sever struct.

## Linked Issues
Link any related issues here. Format: `#[issue number]`

## Type of Change
- [X] Bug Fix
- [X] New Feature
- [ ] Documentation

## Checklist:
- [X] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [X] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings or errors in the compiler or runtime.
- [X] My code is able to build and run on my machine.

## Screenshots (if applicable)
Attach any screenshots or GIFs showcasing the changes effect.

## Additional Notes
Add any other notes about the Pull Request here.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Replace this with your first and last name or an alias]
- GitHub: [Replace with your GitHub username]
- Bluesky: [Replace with your Bluesky handle if you have one]
- Email: [Replace with your email address, or delete this line]
