### PR TITLE
Add missing public memberwise inits

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
@@ -682,6 +682,11 @@ extension ATProtoBluesky {
         /// The language of the captions.
         public let language: Locale
 
+        public init(file: Data, language: Locale) {
+            self.file = file
+            self.language = language
+        }
+
         enum CodingKeys: String, CodingKey {
             case file
             case language = "lang"

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Notification/AppBskyNotificationDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Notification/AppBskyNotificationDefs.swift
@@ -102,6 +102,12 @@ extension AppBskyLexicon.Notification {
         /// Determines whether push notifications for chat messages.
         public let willPush: Bool
 
+        public init(include: Include, willAppearInNotificationList: Bool, willPush: Bool) {
+            self.include = include
+            self.willAppearInNotificationList = willAppearInNotificationList
+            self.willPush = willPush
+        }
+
         enum CodingKeys: String, CodingKey {
             case include
             case willAppearInNotificationList = "list"
@@ -169,6 +175,11 @@ extension AppBskyLexicon.Notification {
 
         /// Determines whether push notifications for chat messages.
         public let willPush: Bool
+
+        public init(willAppearInNotificationList: Bool, willPush: Bool) {
+            self.willAppearInNotificationList = willAppearInNotificationList
+            self.willPush = willPush
+        }
 
         enum CodingKeys: String, CodingKey {
             case willAppearInNotificationList = "list"

--- a/Sources/ATProtoKit/Models/Lexicons/com.atproto/Label/ComAtprotoLabelDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/com.atproto/Label/ComAtprotoLabelDefs.swift
@@ -174,6 +174,10 @@ extension ComAtprotoLexicon.Label {
         /// - Important: Current maximum length is 128 characters.
         public let value: String
 
+        public init(value: String) {
+            self.value = value
+        }
+
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
 


### PR DESCRIPTION
## Description
Several public structs that conform to `Codable` with custom `CodingKeys` were missing explicit public memberwise initializers. Because Swift suppresses the synthesized memberwise init when `CodingKeys` is defined, these types could not be constructed directly — requiring a JSON encode/decode workaround as the only alternative.

This PR adds the missing `public init` to the following types:

- `AppBskyLexicon.Notification.FilterablePreferenceDefinition`
- `AppBskyLexicon.Notification.PreferenceDefinition`
- `ComAtprotoLexicon.Label.SelfLabelDefinition`
- `ATProtoBluesky.Caption`

## Linked Issues
#334

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Documentation

## Checklist:
- [x] My code follows the [ATProtoKit API Design Guidelines](https://github.com/MasterJ93/ATProtoKit/blob/main/API_GUIDELINES.md) as well as the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).
- [x] I have performed a self-review of my own code and commented it, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or errors in the compiler or runtime.
- [x] My code is able to build and run on my machine.

## Screenshots (if applicable)
N/A

## Additional Notes
No behavior changes — existing encode/decode logic is untouched. Only public surface area is expanded.

Documentation was not added to the new initializers. Most public memberwise `init` methods in the existing codebase do not carry DocC comments, so this PR follows the same convention.

## Credits
If you want to be credited in the CONTRIBUTORS file, you can fill out the form below. Please don't remove the square brackets.
- Name: [Keisuke Chinone]
- GitHub: [KC-2001MS]
- Bluesky: [bluesky.iroiro.me]
- Email: [iroiro.work1234@gmail.com]
