### PR TITLE
Update Max Video Size

### DIFF
--- a/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
+++ b/Sources/ATProtoKit/APIReference/ATProtoBlueskyAPI/PostRecord/CreatePostRecord.swift
@@ -720,7 +720,7 @@ extension ATProtoBluesky {
     ) async throws -> AppBskyLexicon.Feed.PostRecord.EmbedUnion {
         // Check if the size of the video is small enough.
         if video.count >= AttachmentLexiconLimit.videoEmbed {
-            throw ATJobStatusError.videoSizeTooLarge(message: "The video file is too large. The maximum file size is currently 100MB.")
+            throw ATJobStatusError.videoSizeTooLarge(message: "The video file is too large. The maximum file size is currently 300MB.")
         }
 
 

--- a/Sources/ATProtoKit/Models/Lexicons/app.bsky/Video/AppBskyVideoDefs.swift
+++ b/Sources/ATProtoKit/Models/Lexicons/app.bsky/Video/AppBskyVideoDefs.swift
@@ -66,17 +66,41 @@ extension AppBskyLexicon.Video {
             /// The job is currently encoding.
             case jobStateEncoding = "JOB_STATE_ENCODING"
 
+            /// The job is encoded.
+            case jobStateEncoded = "JOB_STATE_ENCODED"
+
             /// The job is currently scanning.
             case jobStateScanning = "JOB_STATE_SCANNING"
             
             /// The job is scanned.
             case jobStateScanned = "JOB_STATE_SCANNED"
 
+            /// The job is currently uploading.
+            case jobStateUploading = "JOB_STATE_UPLOADING"
+
+            /// The job is uploaded.
+            case jobStateUploaded = "JOB_STATE_UPLOADED"
+
             /// The job is completed processing.
             case jobStateCompleted = "JOB_STATE_COMPLETED"
 
             /// The job failed to complete the processing.
             case jobStateFailed = "JOB_STATE_FAILED"
+
+            /// A state this version of the lexicon does not name.
+            ///
+            /// `app.bsky.video.defs` declares `state` as an open set: "All values
+            /// not listed as a known value indicate that the job is in process."
+            /// Decoding an unrecognised value as an error fails the whole upload
+            /// the moment the service reports a state added after this type was
+            /// written, so anything unknown lands here and callers treat it the
+            /// same as any other in-progress state.
+            case jobStateInProcess = "JOB_STATE_IN_PROCESS"
+
+            public init(from decoder: any Decoder) throws {
+                let rawValue = try decoder.singleValueContainer().decode(String.self)
+                self = State(rawValue: rawValue) ?? .jobStateInProcess
+            }
         }
     }
 }

--- a/Sources/ATProtoKit/Utilities/AttachmentLexiconLimit.swift
+++ b/Sources/ATProtoKit/Utilities/AttachmentLexiconLimit.swift
@@ -69,14 +69,14 @@ public enum AttachmentLexiconLimit {
     /// [list]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/graph/list.json
     public static let listAvatar = 1_000_000
 
-    /// The maximum size of a video embed: 100,000,000 bytes.
+    /// The maximum size of a video embed: 300,000,000 bytes.
     ///
     /// Declared by `app.bsky.embed.video` at `defs.main.properties.video.maxSize`.
     ///
     /// - SeeAlso: [`app.bsky.embed.video`][video] lexicon.
     ///
     /// [video]: https://github.com/bluesky-social/atproto/blob/main/lexicons/app/bsky/embed/video.json
-    public static let videoEmbed = 100_000_000
+    public static let videoEmbed = 300_000_000
 
     /// The maximum size of a video VTT caption file: 20,000 bytes.
     ///


### PR DESCRIPTION
## Description
Bluesky just randomly decided that videos can be 300MB now. Since ATProtoKit enforces that size, we have to update it here so clients can support larger videos.

In the course of testing this new feature on the client side, I saw that ATProtoKit needed a few more state cases to help troubleshoot upload issues. So I've added those here as well.